### PR TITLE
Def macros: Implicit class support

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -22,9 +22,9 @@ class plus2(val a: Int) {
 }
 
 object ImplicitsForNumbers {
-  implicit class PlusFor(a: Int) {
+  implicit class PlusFor(val a: Int) {
     inline def plus(b: Int): Any = meta {
-      q"this.a + $b"
+      q"$this.a + $b"
     }
   }
 }

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -21,7 +21,6 @@ class plus2(val a: Int) {
   }
 }
 
-/*
 object ImplicitsForNumbers {
   implicit class PlusFor(a: Int) {
     inline def plus(b: Int): Any = meta {
@@ -29,7 +28,6 @@ object ImplicitsForNumbers {
     }
   }
 }
-*/
 
 /*
 object scope {

--- a/macros/src/main/scala/packaged/macros/InnerClassMacro.scala
+++ b/macros/src/main/scala/packaged/macros/InnerClassMacro.scala
@@ -1,0 +1,17 @@
+package packaged.macros
+
+import scala.gestalt._
+
+class InnerClassMacro {
+  def createInner = new Inner()
+  class Inner {
+    inline def plus(a: Int, b: Int) = meta {
+      q"$a + $b"
+    }
+  }
+  object InnerObject {
+    inline def plus(a: Int, b: Int) = meta {
+      q"$a + $b"
+    }
+  }
+}

--- a/macros/src/main/scala/packaged/macros/InnerObjectMacro.scala
+++ b/macros/src/main/scala/packaged/macros/InnerObjectMacro.scala
@@ -1,9 +1,6 @@
 package packaged.macros
 import scala.gestalt._
 
-/**
-  * Created by valdis on 17.28.2.
-  */
 object InnerObjectMacro {
   class Inner {
     inline def plus(a: Int, b: Int) = meta {

--- a/macros/src/main/scala/packaged/macros/InnerObjectMacro.scala
+++ b/macros/src/main/scala/packaged/macros/InnerObjectMacro.scala
@@ -1,0 +1,20 @@
+package packaged.macros
+import scala.gestalt._
+
+/**
+  * Created by valdis on 17.28.2.
+  */
+object InnerObjectMacro {
+  class Inner {
+    inline def plus(a: Int, b: Int) = meta {
+      q"$a + $b"
+    }
+  }
+
+  object InnerObject {
+    inline def plus(a: Int, b: Int) = meta {
+      q"$a + $b"
+    }
+  }
+
+}

--- a/macros/src/main/scala/packaged/macros/PackagedImplicits.scala
+++ b/macros/src/main/scala/packaged/macros/PackagedImplicits.scala
@@ -1,0 +1,13 @@
+package packaged.macros
+
+import scala.gestalt._
+
+object ImplicitsForNumbers {
+
+  implicit class PlusFor(val a: Int) {
+    inline def plus(b: Int): Any = meta {
+      q"$this.a + $b"
+    }
+  }
+
+}

--- a/macros/src/main/scala/packaged/macros/package.scala
+++ b/macros/src/main/scala/packaged/macros/package.scala
@@ -1,0 +1,11 @@
+package packaged
+
+import scala.gestalt._
+
+package object macros {
+  implicit class PlusFor(val a: Int) {
+    inline def plus(b: Int): Any = meta {
+      q"$this.a + $b"
+    }
+  }
+}

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -10,10 +10,10 @@ class DefMacroTest extends TestSuite {
     val p = new plus2(3)
     assert(p(5) == 8)
   }
-  /*  test("implicit plus") {
-      import ImplicitsForNumbers._
-      assert(3.plus(5) == 8)
-    }*/
+  test("implicit plus") {
+    import ImplicitsForNumbers._
+    assert(3.plus(5) == 8)
+  }
   /*
     test("def with type parameters") {
       assert(scope.is[String]("hello"))

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -10,6 +10,29 @@ class DefMacroTest extends TestSuite {
     val p = new plus2(3)
     assert(p(5) == 8)
   }
+
+  test("plus2 returned value") {
+    case class Holder(item: plus2)
+    val holder = Holder(new plus2(3))
+    assert(holder.item.apply(5) == 8)
+    object Generator{
+      def generate = new plus2(21)
+    }
+    assert(Generator.generate.apply(3) == 24)
+    assert(Generator.generate.apply(3) == 24)
+  }
+
+  test("plus2 on expression") {
+    val three = 3
+    assert(new plus2(3)(5) == 8)
+    assert(new plus2(three * 1)(5) == 8)
+  }
+
+/*  test("plus2 on option get") {
+    val option = Some(new plus2(3))
+    assert(option.get.apply(5) == 8)
+  }*/
+
   test("implicit plus") {
     import ImplicitsForNumbers._
     assert(3.plus(5) == 8)

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -30,10 +30,23 @@ class DefMacroTest extends TestSuite {
     assert(new plus2(three * 1)(5) == 8)
   }
 
-/*  test("plus2 on option get") {
-    val option = Some(new plus2(3))
-    assert(option.get.apply(5) == 8)
-  }*/
+  test("plus from inner class") {
+    import packaged.macros.InnerClassMacro
+    val outer = new InnerClassMacro()
+    assert(outer.createInner.plus(5, 3) == 8)
+  }
+
+  test("plus from inner object") {
+    import packaged.macros.InnerClassMacro
+    val outer = new InnerClassMacro()
+    assert(outer.InnerObject.plus(5, 3) == 8)
+  }
+
+
+  /*  test("plus2 on option get") {
+      val option = Some(new plus2(3))
+      assert(option.get.apply(5) == 8)
+    }*/
 
   test("implicit plus") {
     import ImplicitsForNumbers._

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -52,10 +52,10 @@ class DefMacroTest extends TestSuite {
     assert(new InnerObjectMacro.Inner().plus(5, 3) == 8)
   }
 
-  /*  test("plus2 on option get") {
-      val option = Some(new plus2(3))
-      assert(option.get.apply(5) == 8)
-    }*/
+  test("plus2 on option get") {
+    val option = Some(new plus2(3))
+    assert(option.get.apply(5) == 8)
+  }
 
   test("implicit plus") {
     import ImplicitsForNumbers._

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -11,15 +11,17 @@ class DefMacroTest extends TestSuite {
     assert(p(5) == 8)
   }
 
-  test("plus2 returned value") {
+  test("plus2 on method call") {
     case class Holder(item: plus2)
     val holder = Holder(new plus2(3))
     assert(holder.item.apply(5) == 8)
-    object Generator{
-      def generate = new plus2(21)
+
+    object Generator {
+      def fromSeed(seed: Int) = new plus2(seed + 1)
+      def generate = new plus2(42)
     }
-    assert(Generator.generate.apply(3) == 24)
-    assert(Generator.generate.apply(3) == 24)
+    assert(Generator.fromSeed(20).apply(3) == 24)
+    assert(Generator.generate.apply(0) == 42)
   }
 
   test("plus2 on expression") {

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -39,6 +39,17 @@ class DefMacroTest extends TestSuite {
     import ImplicitsForNumbers._
     assert(3.plus(5) == 8)
   }
+
+  test("implicit plus from a package") {
+    import packaged.macros.ImplicitsForNumbers._
+    assert(3.plus(5) == 8)
+  }
+
+  test("implicit plus from a package object") {
+    import packaged.macros._
+    assert(3.plus(5) == 8)
+  }
+
   /*
     test("def with type parameters") {
       assert(scope.is[String]("hello"))

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -30,18 +30,17 @@ class DefMacroTest extends TestSuite {
     assert(new plus2(three * 1)(5) == 8)
   }
 
-  test("plus from inner class") {
+/*  test("plus from inner class") {
     import packaged.macros.InnerClassMacro
     val outer = new InnerClassMacro()
     assert(outer.createInner.plus(5, 3) == 8)
-  }
+  }*/
 
-  test("plus from inner object") {
+/*  test("plus from inner object") {
     import packaged.macros.InnerClassMacro
     val outer = new InnerClassMacro()
     assert(outer.InnerObject.plus(5, 3) == 8)
-  }
-
+  }*/
 
   /*  test("plus2 on option get") {
       val option = Some(new plus2(3))

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -30,17 +30,27 @@ class DefMacroTest extends TestSuite {
     assert(new plus2(three * 1)(5) == 8)
   }
 
-/*  test("plus from inner class") {
+/*  test("plus from class inside class") {
     import packaged.macros.InnerClassMacro
     val outer = new InnerClassMacro()
     assert(outer.createInner.plus(5, 3) == 8)
   }*/
 
-/*  test("plus from inner object") {
+/*  test("plus from object inside class") {
     import packaged.macros.InnerClassMacro
     val outer = new InnerClassMacro()
     assert(outer.InnerObject.plus(5, 3) == 8)
   }*/
+
+  test("plus from object inside object") {
+    import packaged.macros.InnerObjectMacro
+    assert(InnerObjectMacro.InnerObject.plus(5, 3) == 8)
+  }
+
+  test("plus from class inside object") {
+    import packaged.macros.InnerObjectMacro
+    assert(new InnerObjectMacro.Inner().plus(5, 3) == 8)
+  }
 
   /*  test("plus2 on option get") {
       val option = Some(new plus2(3))

--- a/src/main/scala/gestalt/dotty/Expander.scala
+++ b/src/main/scala/gestalt/dotty/Expander.scala
@@ -27,18 +27,11 @@ object Expander {
   }
 
   private def javaClassName(classSymbol: Symbol)(implicit ctx: Context): String = {
-    val owner = classSymbol.owner
-    if (classSymbol == NoSymbol ||
-      owner == NoSymbol ||
-      owner.isEffectiveRoot) {
-      classSymbol.showName
+    val enclosingPackage = classSymbol.enclosingPackageClass
+    if (enclosingPackage.isEffectiveRoot) {
+      classSymbol.flatName.toString
     } else {
-      val enclosingPackage = classSymbol.enclosingPackageClass
-      if (enclosingPackage.isEffectiveRoot) {
-        classSymbol.flatName.toString
-      } else {
-        enclosingPackage.showFullName + "." + classSymbol.flatName
-      }
+      enclosingPackage.showFullName + "." + classSymbol.flatName
     }
   }
 

--- a/src/main/scala/gestalt/dotty/Expander.scala
+++ b/src/main/scala/gestalt/dotty/Expander.scala
@@ -75,16 +75,16 @@ object Expander {
 
   /** Expand def macros */
   def expandDefMacro(tree: tpd.Tree)(implicit ctx: Context): untpd.Tree = tree match {
-    case ExtractApply(Select(obj, method), targs, argss) =>
-      val objType = obj.symbol.info.resultType
-      val className = javaClassName(objType.classSymbol) + "$inline$"
+    case ExtractApply(Select(prefix, method), targs, argss) =>
+      val prefixType = prefix.symbol.info.resultType
+      val className = javaClassName(prefixType.classSymbol) + "$inline$"
       // reflect macros definition
       val moduleClass = ctx.classloader.loadClass(className)
       val module = moduleClass.getField("MODULE$").get(null)
       val impl = moduleClass.getDeclaredMethods().find(_.getName == method.toString).get
       impl.setAccessible(true)
 
-      val trees  = new DottyToolbox() :: obj :: targs ++ argss.flatten
+      val trees  = new DottyToolbox() :: prefix :: targs ++ argss.flatten
       impl.invoke(module, trees: _*).asInstanceOf[untpd.Tree]
     case _ =>
       tree

--- a/src/main/scala/gestalt/dotty/Expander.scala
+++ b/src/main/scala/gestalt/dotty/Expander.scala
@@ -75,9 +75,9 @@ object Expander {
 
   /** Expand def macros */
   def expandDefMacro(tree: tpd.Tree)(implicit ctx: Context): untpd.Tree = tree match {
-    case ExtractApply(Select(prefix, method), targs, argss) =>
-      val prefixType = prefix.symbol.info.resultType
-      val className = javaClassName(prefixType.classSymbol) + "$inline$"
+    case ExtractApply(methodSelect @ Select(prefix, method), targs, argss) =>
+      val classSymbol = methodSelect.symbol.owner
+      val className = javaClassName(classSymbol) + "$inline$"
       // reflect macros definition
       val moduleClass = ctx.classloader.loadClass(className)
       val module = moduleClass.getField("MODULE$").get(null)


### PR DESCRIPTION
- Added tests for applying macros on different prefixes: method calls(with and without arguments), method calls on generic types, constructors.
- ~~Using `info.resultType`, because when the prefix applies a function with arguments, info is a `Method` type which gives a class of `<none>`. In other cases both yield the same class.~~
- Using `Select.symbol.owner` to get the owner of the method. This replaces `info` which gives `<none>` when prefix applies a function with arguments.
- Added macros defined inside packages, outside, inside objects. Created tests applying these macros.
- Added method `javaClassName`. We cannot use `fullName` as the java class name splits inner classes/objects with a dot `.` while java uses `$`.
- Both things needed to be fixed for `ImplicitsForNumbers.PlusFor.plus` macro to work.

Will tackle ~~macros applied on method calls on generic types (i.e. `Some(new plus2(3)).get.apply(5)`)~~ and macros defined from classes/objects inside classes in separate pull requests.