### PR TITLE
Def macros: Inner class support

### DIFF
--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -36,11 +36,11 @@ class DefMacroTest extends TestSuite {
     assert(outer.createInner.plus(5, 3) == 8)
   }
 
-/*  test("plus from object inside class") {
+  test("plus from object inside class") {
     import packaged.macros.InnerClassMacro
     val outer = new InnerClassMacro()
     assert(outer.InnerObject.plus(5, 3) == 8)
-  }*/
+  }
 
   test("plus from object inside object") {
     import packaged.macros.InnerObjectMacro

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -30,11 +30,11 @@ class DefMacroTest extends TestSuite {
     assert(new plus2(three * 1)(5) == 8)
   }
 
-/*  test("plus from class inside class") {
+  test("plus from class inside class") {
     import packaged.macros.InnerClassMacro
     val outer = new InnerClassMacro()
     assert(outer.createInner.plus(5, 3) == 8)
-  }*/
+  }
 
 /*  test("plus from object inside class") {
     import packaged.macros.InnerClassMacro

--- a/src/main/scala/gestalt/dotty/Expander.scala
+++ b/src/main/scala/gestalt/dotty/Expander.scala
@@ -56,7 +56,6 @@ object Expander {
         val className = tpdClass.symbol.fullName + "$inline$"
         // reflect macros definition
         val moduleClass = ctx.classloader.loadClass(className)
-        val module = moduleClass.getField("MODULE$").get(null)
         val impl = moduleClass.getDeclaredMethods().find(_.getName == "apply").get
         impl.setAccessible(true)
 
@@ -64,7 +63,7 @@ object Expander {
           val mods1 = mdef.mods.withAnnotations(mdef.mods.annotations.filter(_ ne ann))
           mdef.withMods(mods1)
         }
-        val result = impl.invoke(module, new DottyToolbox(), ann, expandee).asInstanceOf[untpd.Tree]
+        val result = impl.invoke(null, new DottyToolbox(), ann, expandee).asInstanceOf[untpd.Tree]
         Some(result)
       case _ =>
         None
@@ -80,12 +79,11 @@ object Expander {
       val className = javaClassName(classSymbol) + "$inline$"
       // reflect macros definition
       val moduleClass = ctx.classloader.loadClass(className)
-      val module = moduleClass.getField("MODULE$").get(null)
       val impl = moduleClass.getDeclaredMethods().find(_.getName == method.toString).get
       impl.setAccessible(true)
 
       val trees  = new DottyToolbox() :: prefix :: targs ++ argss.flatten
-      impl.invoke(module, trees: _*).asInstanceOf[untpd.Tree]
+      impl.invoke(null, trees: _*).asInstanceOf[untpd.Tree]
     case _ =>
       tree
   }


### PR DESCRIPTION
Using the static methods introduced by @liufengyun  ['s changes](https://github.com/liufengyun/dotty/commit/43fdbf1e3df3e999acb14e3e32c0980e7280083b) instead of object methods (calls on the `MODULE$` field). 

These calls caused problems because the `MODULE$` field was not generating for objects and classes inside other classes. See  #13 