### PR TITLE
Def macros: tests for type parameters

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -29,14 +29,12 @@ object ImplicitsForNumbers {
   }
 }
 
-/*
 object scope {
-  inline def is[T](a: Any): Any = meta {
+  inline def is[T](a: Any): Boolean = meta {
     q"$a.isInstanceOf[$T]"
   }
 
-  inline def both[S, T](a: Any): Any = meta {
+  inline def both[S, T](a: Any): Boolean = meta {
     q"$a.isInstanceOf[$S] && $a.isInstanceOf[$T]"
   }
 }
-*/

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -72,9 +72,9 @@ class DefMacroTest extends TestSuite {
     assert(3.plus(5) == 8)
   }
 
-  /*
-    test("def with type parameters") {
-      assert(scope.is[String]("hello"))
-      assert(!scope.both[String, List[Int]]("hello"))
-    } */
+
+  test("def with type parameters") {
+    assert(scope.is[String]("hello"))
+    assert(!scope.both[String, List[Int]]("hello"))
+  }
 }


### PR DESCRIPTION
Enabled the tests, the fix is in liufengyun/dotty#1 , fails until the dotty library is updated