### PR TITLE
Quasiquotes: fix for "hole-free" and literals

### DIFF
--- a/macros/src/main/scala/gestalt/macros/Annotations.scala
+++ b/macros/src/main/scala/gestalt/macros/Annotations.scala
@@ -13,6 +13,12 @@ class main extends StaticAnnotation {
   }
 }
 
+class replace extends StaticAnnotation {
+  inline def apply(defn: Any): Any = meta {
+    q"object UnrelatedObject{ def aPrimeNumber = 29 }"
+  }
+}
+
 /*
 class data extends StaticAnnotation {
   inline def apply(defn: Any): Any = meta {

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -46,13 +46,13 @@ object scope {
 }
 
 object trees {
-  inline def some3: Option[Int] = meta {
+  inline def some3(): Option[Int] = meta {
     q"Some(3)"
   }
-  inline def five: Int = meta {
+  inline def five(): Int = meta {
     q"5"
   }
-  inline def pi: Double = meta {
+  inline def pi(): Double = meta {
     q"Math.PI"
   }
   inline def ident(a: Any): Any = meta {

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -15,6 +15,12 @@ class plus {
   }
 }
 
+object plusOne {
+  inline def apply(a: Int): Int =  meta {
+    q"$a + 1"
+  }
+}
+
 class plus2(val a: Int) {
   inline def apply(b: Int): Any = meta {
     q"$this.a + $b"
@@ -36,5 +42,20 @@ object scope {
 
   inline def both[S, T](a: Any): Boolean = meta {
     q"$a.isInstanceOf[$S] && $a.isInstanceOf[$T]"
+  }
+}
+
+object trees {
+  inline def some3: Option[Int] = meta {
+    q"Some(3)"
+  }
+  inline def five: Int = meta {
+    q"5"
+  }
+  inline def pi: Double = meta {
+    q"Math.PI"
+  }
+  inline def ident(a: Any): Any = meta {
+    q"$a"
   }
 }

--- a/macros/src/test/scala/gestalt/macros/AnnotationMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/AnnotationMacroTest.scala
@@ -7,6 +7,12 @@ class AnnotationMacroTest extends TestSuite {
     assert(Test.stub(null) == "hello world!")
   }
 
+  test("replace"){
+    @replace object Replacable
+
+    assert(UnrelatedObject.aPrimeNumber == 29)
+  }
+
   /*
   test("data") {
     @data class Point(x: Int, y: Int)

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -6,6 +6,10 @@ class DefMacroTest extends TestSuite {
     val p = new plus
     assert(p(3, 5) == 8)
   }
+
+  test("plusOne") {
+    assert(plusOne(4) == 5)
+  }
   test("plus2") {
     val p = new plus2(3)
     assert(p(5) == 8)
@@ -72,9 +76,14 @@ class DefMacroTest extends TestSuite {
     assert(3.plus(5) == 8)
   }
 
-
   test("def with type parameters") {
     assert(scope.is[String]("hello"))
     assert(!scope.both[String, List[Int]]("hello"))
+  }
+
+  test("constant quasiqoutes"){
+    assert(trees.five == 5)
+    assert(trees.some3 == Some(3))
+    assert(trees.pi == Math.PI)
   }
 }

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -82,8 +82,8 @@ class DefMacroTest extends TestSuite {
   }
 
   test("constant quasiqoutes"){
-    assert(trees.five == 5)
-    assert(trees.some3 == Some(3))
-    assert(trees.pi == Math.PI)
+    assert(trees.five() == 5)
+    assert(trees.some3() == Some(3))
+    assert(trees.pi() == Math.PI)
   }
 }

--- a/src/main/scala/gestalt/Quote.scala
+++ b/src/main/scala/gestalt/Quote.scala
@@ -184,7 +184,8 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     * */
   def liftValDef(mods: t.Tree, pats: Seq[m.Pat], tpe: t.Tree, rhs: t.Tree, name: String): t.Tree = {
     if (pats.size == 1) {
-      //left: t.Tree[t.Tree[?]] | t.Tree[String]
+      // AnyTree = t.Tree | t.TypeTree
+      //left: t.Tree[AnyTree[?]] | t.Tree[String]
       val left = pats(0) match {
         case quasi: Quasi =>
           liftQuasi(quasi)
@@ -194,9 +195,17 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
           lift(pat)
       }
 
+      // FIXME does not match to any of ${name}.apply signatures
+      // For *Decl does not have a last argument,
+      //  tpe: expected: TypeTree, actual: Option[TypeTree],
+      // For *Def argument rhs: expected: Tree, actual: Option[Nothing]
       selectToolbox(name).appliedTo(mods, left, tpe, scalaNone)
     }
     else
+      // FIXME does not match to any of ${name}.apply signatures
+      // For *Decl does not have a last argument,
+      //  tpe: expected: TypeTree, actual: Option[TypeTree],
+      // For *Def argument rhs: expected: Tree, actual: Option[Tree]
       selectToolbox(name).appliedTo(mods, liftSeq(pats), tpe, rhs)
   }
 

--- a/src/main/scala/gestalt/Quote.scala
+++ b/src/main/scala/gestalt/Quote.scala
@@ -195,7 +195,8 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     case quasi: Quasi  =>
       liftQuasi(quasi)
 
-    case m.Lit(value) => t.Lit(value)
+    case m.Lit(value) =>
+      selectToolbox("Lit").appliedTo(t.Lit(value))
 
     // case m.Name.Anonymous() =>
     // case m.Name.Indeterminate(name) =>

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -12,10 +12,12 @@ import Contexts._
 import Decorators._
 import Constants._
 import d.modsDeco
+import util.Positions
+import Positions.Position
 
 import scala.collection.mutable.ListBuffer
 
-class DottyToolbox(implicit ctx: Context) extends Toolbox {
+class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit ctx: Context) extends Toolbox {
   type Tree = d.Tree
   type TypeTree = d.Tree
   type Type = Types.Type
@@ -410,7 +412,7 @@ class DottyToolbox(implicit ctx: Context) extends Toolbox {
 
   // terms
   object Lit extends LitHelper {
-    def apply(value: Any): Tree = d.Literal(Constant(value))
+    def apply(value: Any): Tree = d.Literal(Constant(value)).withPos(enclosingPosition)
     def unapply(tree: Tree): Option[Any] = tree match {
       case c.Literal(Constant(v)) => Some(v)
       case _ => None
@@ -418,7 +420,7 @@ class DottyToolbox(implicit ctx: Context) extends Toolbox {
   }
 
   object Ident extends IdentHelper {
-    def apply(name: String): Tree = d.Ident(name.toTermName)
+    def apply(name: String): Tree = d.Ident(name.toTermName).withPos(enclosingPosition)
   }
 
   object Select extends SelectHelper {

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -216,7 +216,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
       val body =
         if (tparams.size == 0) rhs
         else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], rhs)
-      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)) //not leaf
+      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods))
     }
   }
 
@@ -224,7 +224,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
     def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: Option[TypeTree], rhs: Tree): Tree = {
       val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
       val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
-      d.DefDef(name.toTermName, types, params, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)) //not leaf
+      d.DefDef(name.toTermName, types, params, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods))
     }
   }
 
@@ -232,46 +232,46 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
     def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: TypeTree): Tree = {
       val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
       val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
-      d.DefDef(name.toTermName, types, params, tpe, d.EmptyTree).withMods(fromMods(mods)) //not leaf
+      d.DefDef(name.toTermName, types, params, tpe, d.EmptyTree).withMods(fromMods(mods))
     }
   }
 
   object ValDef extends ValDefHelper {
     def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)) //not leaf
+      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods))
 
     def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods), List(lhs), tpe.getOrElse(d.TypeTree()), rhs) //not leaf
+      d.PatDef(fromMods(mods), List(lhs), tpe.getOrElse(d.TypeTree()), rhs)
 
     def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods), pats.toList, tpe.getOrElse(d.TypeTree()), rhs) //not leaf
+      d.PatDef(fromMods(mods), pats.toList, tpe.getOrElse(d.TypeTree()), rhs)
   }
 
   object ValDecl extends ValDeclHelper {
     def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods)) //not leaf
+      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods))
 
     def apply(mods: Seq[Tree], vals: Seq[String], tpe: TypeTree): Tree =
-      d.PatDef(fromMods(mods), vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree) //not leaf
+      d.PatDef(fromMods(mods), vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree)
   }
 
   object VarDef extends VarDefHelper {
     def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods) | Flags.Mutable) //not leaf
+      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods) | Flags.Mutable)
 
     def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, List(lhs), tpe.getOrElse(d.TypeTree()), rhs) //not leaf
+      d.PatDef(fromMods(mods) | Flags.Mutable, List(lhs), tpe.getOrElse(d.TypeTree()), rhs)
 
     def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, pats.toList, tpe.getOrElse(d.TypeTree()), rhs) //not leaf
+      d.PatDef(fromMods(mods) | Flags.Mutable, pats.toList, tpe.getOrElse(d.TypeTree()), rhs)
   }
 
   object VarDecl extends VarDeclHelper {
     def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods) | Flags.Mutable) //not leaf
+      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods) | Flags.Mutable)
 
     def apply(mods: Seq[Tree], vals: Seq[String], tpe: TypeTree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree) //not leaf
+      d.PatDef(fromMods(mods) | Flags.Mutable, vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree)
   }
 
   object PrimaryCtor extends PrimaryCtorHelper {
@@ -288,7 +288,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   object SecondaryCtor extends SecondaryCtorHelper {
     def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]], rhs: Tree): Tree =
-      DefDef(mods, nme.CONSTRUCTOR.toString, Nil, paramss, Some(d.TypeTree()), rhs) //not leaf
+      DefDef(mods, nme.CONSTRUCTOR.toString, Nil, paramss, Some(d.TypeTree()), rhs)
   }
 
   // qual.T[A, B](x, y)(z)
@@ -331,7 +331,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   object Self extends SelfHelper {
     def apply(name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree) //not leaf
+      d.ValDef(name.toTermName, tpe, d.EmptyTree)
 
     def apply(name: String): Tree =
       d.ValDef(name.toTermName, d.TypeTree(), d.EmptyTree).withPos(enclosingPosition)
@@ -350,23 +350,23 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object TypeSelect extends TypeSelectHelper {
-    def apply(qual: Tree, name: String): TypeTree = d.Select(qual, name.toTypeName) //not leaf
+    def apply(qual: Tree, name: String): TypeTree = d.Select(qual, name.toTypeName)
   }
 
   object TypeSingleton extends TypeSingletonHelper {
-    def apply(ref: Tree): TypeTree = d.SingletonTypeTree(ref) //not leaf
+    def apply(ref: Tree): TypeTree = d.SingletonTypeTree(ref)
   }
 
   object TypeApply extends TypeApplyHelper {
-    def apply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree = d.AppliedTypeTree(tpe, args.toList) //not leaf
+    def apply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree = d.AppliedTypeTree(tpe, args.toList)
   }
 
   object TypeApplyInfix extends TypeApplyInfixHelper {
-    def apply(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree = d.InfixOp(lhs, d.Ident(op.toTypeName), rhs) //not leaf
+    def apply(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree = d.InfixOp(lhs, d.Ident(op.toTypeName), rhs)
   }
 
   object TypeFunction extends TypeFunctionHelper {
-    def apply(params: Seq[TypeTree], res: TypeTree): TypeTree = d.Function(params.toList, res) //not leaf
+    def apply(params: Seq[TypeTree], res: TypeTree): TypeTree = d.Function(params.toList, res)
   }
 
   object TypeTuple extends TypeTupleHelper {
@@ -374,11 +374,11 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object TypeAnd extends TypeAndHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.AndTypeTree(lhs, rhs) //not leaf
+    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.AndTypeTree(lhs, rhs)
   }
 
   object TypeOr extends TypeOrHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.OrTypeTree(lhs, rhs) //not leaf
+    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.OrTypeTree(lhs, rhs)
   }
 
   object TypeRefine extends TypeRefineHelper {
@@ -389,23 +389,23 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   object TypeBounds extends TypeBoundsHelper {
     def apply(lo: Option[TypeTree], hi: Option[TypeTree]): TypeTree = {
       require(lo.nonEmpty || hi.nonEmpty)
-      d.TypeBoundsTree(lo.getOrElse(d.EmptyTree), hi.getOrElse(d.EmptyTree)) //not leaf
+      d.TypeBoundsTree(lo.getOrElse(d.EmptyTree), hi.getOrElse(d.EmptyTree))
     }
   }
 
   object TypeRepeated extends TypeRepeatedHelper {
-    def apply(tpe: TypeTree): TypeTree = d.PostfixOp(tpe, d.Ident(nme.raw.STAR)) //not leaf
+    def apply(tpe: TypeTree): TypeTree = d.PostfixOp(tpe, d.Ident(nme.raw.STAR))
   }
 
   object TypeByName extends TypeByNameHelper {
-    def apply(tpe: TypeTree): TypeTree = d.ByNameTypeTree(tpe) //not leaf
+    def apply(tpe: TypeTree): TypeTree = d.ByNameTypeTree(tpe)
   }
 
   object TypeAnnotated extends TypeAnnotatedHelper {
     def apply(tpe: TypeTree, annots: Seq[Tree]): TypeTree = {
       require(annots.size > 0)
-      annots.tail.foldRight(d.Annotated(tpe, annots.head)/*not leaf*/) { (ann, acc) =>
-        d.Annotated(acc, ann) //not leaf
+      annots.tail.foldRight(d.Annotated(tpe, annots.head)) { (ann, acc) =>
+        d.Annotated(acc, ann)
       }
     }
   }
@@ -424,12 +424,12 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object Select extends SelectHelper {
-    def apply(qual: Tree, name: String): Tree = d.Select(qual, name.toTermName) //not leaf
+    def apply(qual: Tree, name: String): Tree = d.Select(qual, name.toTermName)
   }
 
   object This extends ThisHelper {
     def apply(qual: String): Tree = d.This(d.Ident(qual.toTypeName)).withPos(enclosingPosition)
-    def apply(qual: Tree): Tree = d.This(qual.asInstanceOf[d.Ident]) //not leaf
+    def apply(qual: Tree): Tree = d.This(qual.asInstanceOf[d.Ident])
   }
 
   object Super extends SuperHelper {
@@ -458,7 +458,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object Apply extends ApplyHelper {
-    def apply(fun: Tree, args: Seq[Tree]): Tree = d.Apply(fun, args.toList) //not leaf
+    def apply(fun: Tree, args: Seq[Tree]): Tree = d.Apply(fun, args.toList)
     def unapply(tree: Tree): Option[(Tree, Seq[Tree])] = tree match {
       case c.Apply(fun, args) => Some((fun, args))
       case _ => None
@@ -466,7 +466,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object ApplyType extends ApplyTypeHelper {
-    def apply(fun: Tree, args: Seq[TypeTree]): Tree = d.TypeApply(fun, args.toList) //not leaf
+    def apply(fun: Tree, args: Seq[TypeTree]): Tree = d.TypeApply(fun, args.toList)
 
     def unapply(tree: Tree): Option[(Tree, Seq[TypeTree])] = tree match {
       case c.TypeApply(fun, args) => Some((fun, args))
@@ -476,20 +476,20 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   // a + (b, c)  =>  Infix(a, +, Tuple(b, c))
   object Infix extends InfixHelper {
-    def apply(lhs: Tree, op: String, rhs: Tree): Tree = //not leaf
+    def apply(lhs: Tree, op: String, rhs: Tree): Tree =
       d.Apply(d.Select(lhs, op.toTermName), List(rhs))
   }
 
   object Prefix extends PrefixHelper {
-    def apply(op: String, od: Tree): Tree = d.PrefixOp(d.Ident(op.toTermName), od) //not leaf
+    def apply(op: String, od: Tree): Tree = d.PrefixOp(d.Ident(op.toTermName), od)
   }
 
   object Postfix extends PostfixHelper {
-    def apply(od: Tree, op: String): Tree = d.PostfixOp(od, d.Ident(op.toTermName)) //not leaf
+    def apply(od: Tree, op: String): Tree = d.PostfixOp(od, d.Ident(op.toTermName))
   }
 
   object Assign extends AssignHelper {
-    def apply(lhs: Tree, rhs: Tree): Tree = d.Assign(lhs, rhs) //not leaf
+    def apply(lhs: Tree, rhs: Tree): Tree = d.Assign(lhs, rhs)
 
     def unapply(tree: Tree): Option[(Tree, Tree)] = tree match {
       case c.Assign(lhs, rhs) => Some((lhs, rhs))
@@ -498,22 +498,22 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object Return extends ReturnHelper {
-    def apply(expr: Tree): Tree = d.Return(expr, d.EmptyTree) //not leaf
+    def apply(expr: Tree): Tree = d.Return(expr, d.EmptyTree)
   }
 
   object Throw extends ThrowHelper {
-    def apply(expr: Tree): Tree = d.Throw(expr) //not leaf
+    def apply(expr: Tree): Tree = d.Throw(expr)
   }
 
   object Ascribe extends AscribeHelper {
-    def apply(expr: Tree, tpe: Tree): Tree = d.Typed(expr, tpe) //not leaf
+    def apply(expr: Tree, tpe: Tree): Tree = d.Typed(expr, tpe)
   }
 
   object Annotated extends AnnotatedHelper {
     def apply(expr: Tree, annots: Seq[Tree]): Tree = {
       require(annots.size > 0)
-      annots.tail.foldRight(d.Annotated(expr, annots.head)/*not leaf*/) { (ann, acc) =>
-        d.Annotated(acc, ann) //not leaf
+      annots.tail.foldRight(d.Annotated(expr, annots.head)) { (ann, acc) =>
+        d.Annotated(acc, ann)
       }
     }
   }
@@ -527,36 +527,36 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
       if (stats.size == 0)
         d.Block(stats.toList, d.EmptyTree).withPos(enclosingPosition)
       else
-        d.Block(stats.init.toList, stats.last) //not leaf
+        d.Block(stats.init.toList, stats.last)
     }
   }
 
   object If extends IfHelper {
     def apply(cond: Tree, thenp: Tree, elsep: Option[Tree]): Tree =
-      d.If(cond, thenp, elsep.getOrElse(d.EmptyTree)) //not leaf
+      d.If(cond, thenp, elsep.getOrElse(d.EmptyTree))
   }
 
   object Match extends MatchHelper {
     def apply(expr: Tree, cases: Seq[Tree]): Tree =
-      d.Match(expr, cases.toList.asInstanceOf[List[d.CaseDef]]) //not leaf
+      d.Match(expr, cases.toList.asInstanceOf[List[d.CaseDef]])
   }
 
   object Case extends CaseHelper {
     def apply(pat: Tree, cond: Option[Tree], body: Tree): Tree =
-      d.CaseDef(pat, cond.getOrElse(d.EmptyTree), body) //not leaf
+      d.CaseDef(pat, cond.getOrElse(d.EmptyTree), body)
   }
 
   object Try extends TryHelper {
     def apply(expr: Tree, cases: Seq[Tree], finallyp: Option[Tree]): Tree =
-      d.Try(expr, cases.toList.asInstanceOf[List[d.CaseDef]], finallyp.getOrElse(d.EmptyTree)) //not leaf
+      d.Try(expr, cases.toList.asInstanceOf[List[d.CaseDef]], finallyp.getOrElse(d.EmptyTree))
 
     def apply(expr: Tree, handler: Tree, finallyp: Option[Tree]): Tree =
-      d.ParsedTry(expr, handler, finallyp.getOrElse(d.EmptyTree)) //not leaf
+      d.ParsedTry(expr, handler, finallyp.getOrElse(d.EmptyTree))
   }
 
   object Function extends FunctionHelper {
     def apply(params: Seq[Tree], body: Tree): Tree =
-      d.Function(params.toList, body) //not leaf
+      d.Function(params.toList, body)
   }
 
   object PartialFunction extends PartialFunctionHelper {
@@ -565,11 +565,11 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object While extends WhileHelper {
-    def apply(expr: Tree, body: Tree): Tree = d.WhileDo(expr, body) //not leaf
+    def apply(expr: Tree, body: Tree): Tree = d.WhileDo(expr, body)
   }
 
   object DoWhile extends DoWhileHelper {
-    def apply(body: Tree, expr: Tree): Tree = d.DoWhile(body, expr) //not leaf
+    def apply(body: Tree, expr: Tree): Tree = d.DoWhile(body, expr)
   }
 
   object For extends ForHelper {
@@ -594,28 +594,28 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   // can be InitCall or AnonymClass
   object New extends NewHelper {
-    def apply(tpe: Tree): Tree = d.New(tpe) //not leaf
+    def apply(tpe: Tree): Tree = d.New(tpe)
   }
 
   object Named extends NamedHelper {
     def apply(name: String, expr: Tree): Tree =
-      d.NamedArg(name.toTermName, expr) //not leaf
+      d.NamedArg(name.toTermName, expr)
   }
 
   object Repeated extends RepeatedHelper {
     def apply(expr: Tree): Tree =
-      d.Typed(expr, d.Ident(tpnme.WILDCARD_STAR)) //not leaf
+      d.Typed(expr, d.Ident(tpnme.WILDCARD_STAR))
   }
 
   // patterns
   object Bind extends BindHelper {
     def apply(name: String, expr: Tree): Tree =
-      d.Bind(name.toTermName, expr) //not leaf
+      d.Bind(name.toTermName, expr)
   }
 
   object Alternative extends AlternativeHelper {
     def apply(lhs: Tree, rhs: Tree): Tree =
-      d.Alternative(List(lhs, rhs)) //not leaf
+      d.Alternative(List(lhs, rhs))
   }
 
   // importees
@@ -629,7 +629,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   object ImportItem extends ImportItemHelper {
     def apply(ref: Tree, importees: Seq[Tree]): Tree =
-      d.Import(ref, importees.toList) //not leaf
+      d.Import(ref, importees.toList)
   }
 
   object ImportName extends ImportNameHelper {

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -216,7 +216,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
       val body =
         if (tparams.size == 0) rhs
         else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], rhs)
-      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods))
+      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPos(enclosingPosition)
     }
   }
 
@@ -224,7 +224,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
     def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: Option[TypeTree], rhs: Tree): Tree = {
       val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
       val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
-      d.DefDef(name.toTermName, types, params, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods))
+      d.DefDef(name.toTermName, types, params, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)).withPos(enclosingPosition)
     }
   }
 
@@ -232,46 +232,46 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
     def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: TypeTree): Tree = {
       val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
       val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
-      d.DefDef(name.toTermName, types, params, tpe, d.EmptyTree).withMods(fromMods(mods))
+      d.DefDef(name.toTermName, types, params, tpe, d.EmptyTree).withMods(fromMods(mods)).withPos(enclosingPosition)
     }
   }
 
   object ValDef extends ValDefHelper {
     def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods))
+      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)).withPos(enclosingPosition)
 
     def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods), List(lhs), tpe.getOrElse(d.TypeTree()), rhs)
+      d.PatDef(fromMods(mods), List(lhs), tpe.getOrElse(d.TypeTree()), rhs).withPos(enclosingPosition)
 
     def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods), pats.toList, tpe.getOrElse(d.TypeTree()), rhs)
+      d.PatDef(fromMods(mods), pats.toList, tpe.getOrElse(d.TypeTree()), rhs).withPos(enclosingPosition)
   }
 
   object ValDecl extends ValDeclHelper {
     def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods))
+      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods)).withPos(enclosingPosition)
 
     def apply(mods: Seq[Tree], vals: Seq[String], tpe: TypeTree): Tree =
-      d.PatDef(fromMods(mods), vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree)
+      d.PatDef(fromMods(mods), vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree).withPos(enclosingPosition)
   }
 
   object VarDef extends VarDefHelper {
     def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods) | Flags.Mutable)
+      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods) | Flags.Mutable).withPos(enclosingPosition)
 
     def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, List(lhs), tpe.getOrElse(d.TypeTree()), rhs)
+      d.PatDef(fromMods(mods) | Flags.Mutable, List(lhs), tpe.getOrElse(d.TypeTree()), rhs).withPos(enclosingPosition)
 
     def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, pats.toList, tpe.getOrElse(d.TypeTree()), rhs)
+      d.PatDef(fromMods(mods) | Flags.Mutable, pats.toList, tpe.getOrElse(d.TypeTree()), rhs).withPos(enclosingPosition)
   }
 
   object VarDecl extends VarDeclHelper {
     def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods) | Flags.Mutable)
+      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods) | Flags.Mutable).withPos(enclosingPosition)
 
     def apply(mods: Seq[Tree], vals: Seq[String], tpe: TypeTree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree)
+      d.PatDef(fromMods(mods) | Flags.Mutable, vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree).withPos(enclosingPosition)
   }
 
   object PrimaryCtor extends PrimaryCtorHelper {
@@ -288,7 +288,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   object SecondaryCtor extends SecondaryCtorHelper {
     def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]], rhs: Tree): Tree =
-      DefDef(mods, nme.CONSTRUCTOR.toString, Nil, paramss, Some(d.TypeTree()), rhs)
+      DefDef(mods, nme.CONSTRUCTOR.toString, Nil, paramss, Some(d.TypeTree()), rhs).withPos(enclosingPosition)
   }
 
   // qual.T[A, B](x, y)(z)
@@ -331,7 +331,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   object Self extends SelfHelper {
     def apply(name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree)
+      d.ValDef(name.toTermName, tpe, d.EmptyTree).withPos(enclosingPosition)
 
     def apply(name: String): Tree =
       d.ValDef(name.toTermName, d.TypeTree(), d.EmptyTree).withPos(enclosingPosition)
@@ -350,23 +350,23 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object TypeSelect extends TypeSelectHelper {
-    def apply(qual: Tree, name: String): TypeTree = d.Select(qual, name.toTypeName)
+    def apply(qual: Tree, name: String): TypeTree = d.Select(qual, name.toTypeName).withPos(enclosingPosition)
   }
 
   object TypeSingleton extends TypeSingletonHelper {
-    def apply(ref: Tree): TypeTree = d.SingletonTypeTree(ref)
+    def apply(ref: Tree): TypeTree = d.SingletonTypeTree(ref).withPos(enclosingPosition)
   }
 
   object TypeApply extends TypeApplyHelper {
-    def apply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree = d.AppliedTypeTree(tpe, args.toList)
+    def apply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree = d.AppliedTypeTree(tpe, args.toList).withPos(enclosingPosition)
   }
 
   object TypeApplyInfix extends TypeApplyInfixHelper {
-    def apply(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree = d.InfixOp(lhs, d.Ident(op.toTypeName), rhs)
+    def apply(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree = d.InfixOp(lhs, d.Ident(op.toTypeName), rhs).withPos(enclosingPosition)
   }
 
   object TypeFunction extends TypeFunctionHelper {
-    def apply(params: Seq[TypeTree], res: TypeTree): TypeTree = d.Function(params.toList, res)
+    def apply(params: Seq[TypeTree], res: TypeTree): TypeTree = d.Function(params.toList, res).withPos(enclosingPosition)
   }
 
   object TypeTuple extends TypeTupleHelper {
@@ -374,11 +374,11 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object TypeAnd extends TypeAndHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.AndTypeTree(lhs, rhs)
+    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.AndTypeTree(lhs, rhs).withPos(enclosingPosition)
   }
 
   object TypeOr extends TypeOrHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.OrTypeTree(lhs, rhs)
+    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.OrTypeTree(lhs, rhs).withPos(enclosingPosition)
   }
 
   object TypeRefine extends TypeRefineHelper {
@@ -389,23 +389,23 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   object TypeBounds extends TypeBoundsHelper {
     def apply(lo: Option[TypeTree], hi: Option[TypeTree]): TypeTree = {
       require(lo.nonEmpty || hi.nonEmpty)
-      d.TypeBoundsTree(lo.getOrElse(d.EmptyTree), hi.getOrElse(d.EmptyTree))
+      d.TypeBoundsTree(lo.getOrElse(d.EmptyTree), hi.getOrElse(d.EmptyTree)).withPos(enclosingPosition)
     }
   }
 
   object TypeRepeated extends TypeRepeatedHelper {
-    def apply(tpe: TypeTree): TypeTree = d.PostfixOp(tpe, d.Ident(nme.raw.STAR))
+    def apply(tpe: TypeTree): TypeTree = d.PostfixOp(tpe, d.Ident(nme.raw.STAR)).withPos(enclosingPosition)
   }
 
   object TypeByName extends TypeByNameHelper {
-    def apply(tpe: TypeTree): TypeTree = d.ByNameTypeTree(tpe)
+    def apply(tpe: TypeTree): TypeTree = d.ByNameTypeTree(tpe).withPos(enclosingPosition)
   }
 
   object TypeAnnotated extends TypeAnnotatedHelper {
     def apply(tpe: TypeTree, annots: Seq[Tree]): TypeTree = {
       require(annots.size > 0)
-      annots.tail.foldRight(d.Annotated(tpe, annots.head)) { (ann, acc) =>
-        d.Annotated(acc, ann)
+      annots.tail.foldRight(d.Annotated(tpe, annots.head).withPos(enclosingPosition)) { (ann, acc) =>
+        d.Annotated(acc, ann).withPos(enclosingPosition)
       }
     }
   }
@@ -424,12 +424,12 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object Select extends SelectHelper {
-    def apply(qual: Tree, name: String): Tree = d.Select(qual, name.toTermName)
+    def apply(qual: Tree, name: String): Tree = d.Select(qual, name.toTermName).withPos(enclosingPosition)
   }
 
   object This extends ThisHelper {
     def apply(qual: String): Tree = d.This(d.Ident(qual.toTypeName)).withPos(enclosingPosition)
-    def apply(qual: Tree): Tree = d.This(qual.asInstanceOf[d.Ident])
+    def apply(qual: Tree): Tree = d.This(qual.asInstanceOf[d.Ident]).withPos(enclosingPosition)
   }
 
   object Super extends SuperHelper {
@@ -458,7 +458,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object Apply extends ApplyHelper {
-    def apply(fun: Tree, args: Seq[Tree]): Tree = d.Apply(fun, args.toList)
+    def apply(fun: Tree, args: Seq[Tree]): Tree = d.Apply(fun, args.toList).withPos(enclosingPosition)
     def unapply(tree: Tree): Option[(Tree, Seq[Tree])] = tree match {
       case c.Apply(fun, args) => Some((fun, args))
       case _ => None
@@ -466,7 +466,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object ApplyType extends ApplyTypeHelper {
-    def apply(fun: Tree, args: Seq[TypeTree]): Tree = d.TypeApply(fun, args.toList)
+    def apply(fun: Tree, args: Seq[TypeTree]): Tree = d.TypeApply(fun, args.toList).withPos(enclosingPosition)
 
     def unapply(tree: Tree): Option[(Tree, Seq[TypeTree])] = tree match {
       case c.TypeApply(fun, args) => Some((fun, args))
@@ -477,19 +477,19 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   // a + (b, c)  =>  Infix(a, +, Tuple(b, c))
   object Infix extends InfixHelper {
     def apply(lhs: Tree, op: String, rhs: Tree): Tree =
-      d.Apply(d.Select(lhs, op.toTermName), List(rhs))
+      d.Apply(d.Select(lhs, op.toTermName), List(rhs)).withPos(enclosingPosition)
   }
 
   object Prefix extends PrefixHelper {
-    def apply(op: String, od: Tree): Tree = d.PrefixOp(d.Ident(op.toTermName), od)
+    def apply(op: String, od: Tree): Tree = d.PrefixOp(d.Ident(op.toTermName), od).withPos(enclosingPosition)
   }
 
   object Postfix extends PostfixHelper {
-    def apply(od: Tree, op: String): Tree = d.PostfixOp(od, d.Ident(op.toTermName))
+    def apply(od: Tree, op: String): Tree = d.PostfixOp(od, d.Ident(op.toTermName)).withPos(enclosingPosition)
   }
 
   object Assign extends AssignHelper {
-    def apply(lhs: Tree, rhs: Tree): Tree = d.Assign(lhs, rhs)
+    def apply(lhs: Tree, rhs: Tree): Tree = d.Assign(lhs, rhs).withPos(enclosingPosition)
 
     def unapply(tree: Tree): Option[(Tree, Tree)] = tree match {
       case c.Assign(lhs, rhs) => Some((lhs, rhs))
@@ -498,22 +498,22 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object Return extends ReturnHelper {
-    def apply(expr: Tree): Tree = d.Return(expr, d.EmptyTree)
+    def apply(expr: Tree): Tree = d.Return(expr, d.EmptyTree).withPos(enclosingPosition)
   }
 
   object Throw extends ThrowHelper {
-    def apply(expr: Tree): Tree = d.Throw(expr)
+    def apply(expr: Tree): Tree = d.Throw(expr).withPos(enclosingPosition)
   }
 
   object Ascribe extends AscribeHelper {
-    def apply(expr: Tree, tpe: Tree): Tree = d.Typed(expr, tpe)
+    def apply(expr: Tree, tpe: Tree): Tree = d.Typed(expr, tpe).withPos(enclosingPosition)
   }
 
   object Annotated extends AnnotatedHelper {
     def apply(expr: Tree, annots: Seq[Tree]): Tree = {
       require(annots.size > 0)
-      annots.tail.foldRight(d.Annotated(expr, annots.head)) { (ann, acc) =>
-        d.Annotated(acc, ann)
+      annots.tail.foldRight(d.Annotated(expr, annots.head).withPos(enclosingPosition)) { (ann, acc) =>
+        d.Annotated(acc, ann).withPos(enclosingPosition)
       }
     }
   }
@@ -527,36 +527,36 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
       if (stats.size == 0)
         d.Block(stats.toList, d.EmptyTree).withPos(enclosingPosition)
       else
-        d.Block(stats.init.toList, stats.last)
+        d.Block(stats.init.toList, stats.last).withPos(enclosingPosition)
     }
   }
 
   object If extends IfHelper {
     def apply(cond: Tree, thenp: Tree, elsep: Option[Tree]): Tree =
-      d.If(cond, thenp, elsep.getOrElse(d.EmptyTree))
+      d.If(cond, thenp, elsep.getOrElse(d.EmptyTree)).withPos(enclosingPosition)
   }
 
   object Match extends MatchHelper {
     def apply(expr: Tree, cases: Seq[Tree]): Tree =
-      d.Match(expr, cases.toList.asInstanceOf[List[d.CaseDef]])
+      d.Match(expr, cases.toList.asInstanceOf[List[d.CaseDef]]).withPos(enclosingPosition)
   }
 
   object Case extends CaseHelper {
     def apply(pat: Tree, cond: Option[Tree], body: Tree): Tree =
-      d.CaseDef(pat, cond.getOrElse(d.EmptyTree), body)
+      d.CaseDef(pat, cond.getOrElse(d.EmptyTree), body).withPos(enclosingPosition)
   }
 
   object Try extends TryHelper {
     def apply(expr: Tree, cases: Seq[Tree], finallyp: Option[Tree]): Tree =
-      d.Try(expr, cases.toList.asInstanceOf[List[d.CaseDef]], finallyp.getOrElse(d.EmptyTree))
+      d.Try(expr, cases.toList.asInstanceOf[List[d.CaseDef]], finallyp.getOrElse(d.EmptyTree)).withPos(enclosingPosition)
 
     def apply(expr: Tree, handler: Tree, finallyp: Option[Tree]): Tree =
-      d.ParsedTry(expr, handler, finallyp.getOrElse(d.EmptyTree))
+      d.ParsedTry(expr, handler, finallyp.getOrElse(d.EmptyTree)).withPos(enclosingPosition)
   }
 
   object Function extends FunctionHelper {
     def apply(params: Seq[Tree], body: Tree): Tree =
-      d.Function(params.toList, body)
+      d.Function(params.toList, body).withPos(enclosingPosition)
   }
 
   object PartialFunction extends PartialFunctionHelper {
@@ -565,11 +565,11 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object While extends WhileHelper {
-    def apply(expr: Tree, body: Tree): Tree = d.WhileDo(expr, body)
+    def apply(expr: Tree, body: Tree): Tree = d.WhileDo(expr, body).withPos(enclosingPosition)
   }
 
   object DoWhile extends DoWhileHelper {
-    def apply(body: Tree, expr: Tree): Tree = d.DoWhile(body, expr)
+    def apply(body: Tree, expr: Tree): Tree = d.DoWhile(body, expr).withPos(enclosingPosition)
   }
 
   object For extends ForHelper {
@@ -594,28 +594,28 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   // can be InitCall or AnonymClass
   object New extends NewHelper {
-    def apply(tpe: Tree): Tree = d.New(tpe)
+    def apply(tpe: Tree): Tree = d.New(tpe).withPos(enclosingPosition)
   }
 
   object Named extends NamedHelper {
     def apply(name: String, expr: Tree): Tree =
-      d.NamedArg(name.toTermName, expr)
+      d.NamedArg(name.toTermName, expr).withPos(enclosingPosition)
   }
 
   object Repeated extends RepeatedHelper {
     def apply(expr: Tree): Tree =
-      d.Typed(expr, d.Ident(tpnme.WILDCARD_STAR))
+      d.Typed(expr, d.Ident(tpnme.WILDCARD_STAR)).withPos(enclosingPosition)
   }
 
   // patterns
   object Bind extends BindHelper {
     def apply(name: String, expr: Tree): Tree =
-      d.Bind(name.toTermName, expr)
+      d.Bind(name.toTermName, expr).withPos(enclosingPosition)
   }
 
   object Alternative extends AlternativeHelper {
     def apply(lhs: Tree, rhs: Tree): Tree =
-      d.Alternative(List(lhs, rhs))
+      d.Alternative(List(lhs, rhs)).withPos(enclosingPosition)
   }
 
   // importees
@@ -629,7 +629,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   object ImportItem extends ImportItemHelper {
     def apply(ref: Tree, importees: Seq[Tree]): Tree =
-      d.Import(ref, importees.toList)
+      d.Import(ref, importees.toList).withPos(enclosingPosition)
   }
 
   object ImportName extends ImportNameHelper {

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -28,6 +28,10 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
 
   def getOrEmpty(treeOpt: Option[Tree]): Tree = treeOpt.getOrElse(d.EmptyTree)
 
+  implicit class TreeHelper(tree: d.Tree) {
+    def withPosition = tree.withPos(enclosingPosition)
+  }
+
   private implicit def fromMods(mods: Seq[Tree]): d.Modifiers = {
     def addMod(modifiers: d.Modifiers, mod: d.Mod): d.Modifiers =
       modifiers.withAddedMod(mod) | mod.flags
@@ -137,7 +141,7 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
       val constr = d.DefDef(nme.CONSTRUCTOR, Nil, Nil, d.TypeTree(), d.EmptyTree)
       val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
       val templ = d.Template(constr, parents.toList, self, stats)
-      d.ModuleDef(name.toTermName, templ).withMods(fromMods(mods)).withPos(enclosingPosition)
+      d.ModuleDef(name.toTermName, templ).withMods(fromMods(mods)).withPosition
     }
 
     def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree])] = tree match {
@@ -161,7 +165,7 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
 
       val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
       val templ = d.Template(constr, parents.toList, self, stats)
-      d.TypeDef(name.toTypeName, templ).withMods(fromMods(mods)).withPos(enclosingPosition)
+      d.TypeDef(name.toTypeName, templ).withMods(fromMods(mods)).withPosition
     }
 
     def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])] = tree match {
@@ -183,13 +187,13 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
     def apply(parents: Seq[Tree], selfOpt: Option[Tree], stats: Seq[Tree]): Tree = {
       val init = d.DefDef(nme.CONSTRUCTOR, List(), List(), d.TypeTree(), d.EmptyTree)
       val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
-      d.Template(init, parents.toList, self, stats).withPos(enclosingPosition)
+      d.Template(init, parents.toList, self, stats).withPosition
     }
   }
 
   object Trait extends TraitHelper {
     def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], ctor: Option[Tree], parents: Seq[Tree], self: Option[Tree], stats: Seq[Tree]): Tree =
-      Class(mods, name, tparams, ctor, parents, self, stats).asInstanceOf[d.TypeDef].withFlags(Flags.Trait).withPos(enclosingPosition)
+      Class(mods, name, tparams, ctor, parents, self, stats).asInstanceOf[d.TypeDef].withFlags(Flags.Trait).withPosition
 
     def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])] =
       if (!tree.isInstanceOf[d.TypeDef]) return None
@@ -207,7 +211,7 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
       val body =
         if (tparams.size == 0) tbounds
         else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], tbounds)
-      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPos(enclosingPosition)
+      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPosition
     }
   }
 
@@ -216,7 +220,7 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
       val body =
         if (tparams.size == 0) rhs
         else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], rhs)
-      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPos(enclosingPosition)
+      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPosition
     }
   }
 
@@ -224,7 +228,7 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
     def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: Option[TypeTree], rhs: Tree): Tree = {
       val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
       val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
-      d.DefDef(name.toTermName, types, params, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)).withPos(enclosingPosition)
+      d.DefDef(name.toTermName, types, params, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)).withPosition
     }
   }
 
@@ -232,53 +236,53 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
     def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: TypeTree): Tree = {
       val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
       val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
-      d.DefDef(name.toTermName, types, params, tpe, d.EmptyTree).withMods(fromMods(mods)).withPos(enclosingPosition)
+      d.DefDef(name.toTermName, types, params, tpe, d.EmptyTree).withMods(fromMods(mods)).withPosition
     }
   }
 
   object ValDef extends ValDefHelper {
     def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)).withPos(enclosingPosition)
+      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)).withPosition
 
     def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods), List(lhs), tpe.getOrElse(d.TypeTree()), rhs).withPos(enclosingPosition)
+      d.PatDef(fromMods(mods), List(lhs), tpe.getOrElse(d.TypeTree()), rhs).withPosition
 
     def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods), pats.toList, tpe.getOrElse(d.TypeTree()), rhs).withPos(enclosingPosition)
+      d.PatDef(fromMods(mods), pats.toList, tpe.getOrElse(d.TypeTree()), rhs).withPosition
   }
 
   object ValDecl extends ValDeclHelper {
     def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods)).withPos(enclosingPosition)
+      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods)).withPosition
 
     def apply(mods: Seq[Tree], vals: Seq[String], tpe: TypeTree): Tree =
-      d.PatDef(fromMods(mods), vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree).withPos(enclosingPosition)
+      d.PatDef(fromMods(mods), vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree).withPosition
   }
 
   object VarDef extends VarDefHelper {
     def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods) | Flags.Mutable).withPos(enclosingPosition)
+      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods) | Flags.Mutable).withPosition
 
     def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, List(lhs), tpe.getOrElse(d.TypeTree()), rhs).withPos(enclosingPosition)
+      d.PatDef(fromMods(mods) | Flags.Mutable, List(lhs), tpe.getOrElse(d.TypeTree()), rhs).withPosition
 
     def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, pats.toList, tpe.getOrElse(d.TypeTree()), rhs).withPos(enclosingPosition)
+      d.PatDef(fromMods(mods) | Flags.Mutable, pats.toList, tpe.getOrElse(d.TypeTree()), rhs).withPosition
   }
 
   object VarDecl extends VarDeclHelper {
     def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods) | Flags.Mutable).withPos(enclosingPosition)
+      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods) | Flags.Mutable).withPosition
 
     def apply(mods: Seq[Tree], vals: Seq[String], tpe: TypeTree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree).withPos(enclosingPosition)
+      d.PatDef(fromMods(mods) | Flags.Mutable, vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree).withPosition
   }
 
   object PrimaryCtor extends PrimaryCtorHelper {
     // Dummy trees to retrofit Dotty AST
     private case class PrimaryCtorTree(mods: Seq[Tree], paramss: Seq[Seq[Tree]]) extends d.Tree
 
-    def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]]): Tree = PrimaryCtorTree(mods, paramss).withPos(enclosingPosition)
+    def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]]): Tree = PrimaryCtorTree(mods, paramss).withPosition
 
     def unapply(tree: Tree): Option[(Seq[Tree], Seq[Seq[Tree]])] = tree match {
       case PrimaryCtorTree(mods, paramss) => Some((mods, paramss))
@@ -288,7 +292,7 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
 
   object SecondaryCtor extends SecondaryCtorHelper {
     def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]], rhs: Tree): Tree =
-      DefDef(mods, nme.CONSTRUCTOR.toString, Nil, paramss, Some(d.TypeTree()), rhs).withPos(enclosingPosition)
+      DefDef(mods, nme.CONSTRUCTOR.toString, Nil, paramss, Some(d.TypeTree()), rhs).withPosition
   }
 
   // qual.T[A, B](x, y)(z)
@@ -296,13 +300,13 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
     def apply(qual: Option[Tree], name: String, tparams: Seq[TypeTree], argss: Seq[Seq[Tree]]): Tree = {
       val select = if (qual.isEmpty) d.Ident(name.toTermName) else d.Select(qual.get, name.toTypeName)
       val fun = if (tparams.size == 0) select else TypeApply(select, tparams.toList)
-      ApplySeq(fun, argss).withPos(enclosingPosition)
+      ApplySeq(fun, argss).withPosition
     }
   }
 
   object Param extends ParamHelper {
     def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], default: Option[Tree]): Tree = {
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), getOrEmpty(default)).withMods(fromMods(mods)).withFlags(Flags.TermParam).withPos(enclosingPosition)
+      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), getOrEmpty(default)).withMods(fromMods(mods)).withFlags(Flags.TermParam).withPosition
     }
 
     def unapply(tree: Tree): Option[(Seq[Tree], String, Option[TypeTree], Option[Tree])] = tree match {
@@ -325,16 +329,16 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
         if (tparams.size == 0) inner
         else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], inner)
 
-      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPos(enclosingPosition)
+      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPosition
     }
   }
 
   object Self extends SelfHelper {
     def apply(name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withPos(enclosingPosition)
+      d.ValDef(name.toTermName, tpe, d.EmptyTree).withPosition
 
     def apply(name: String): Tree =
-      d.ValDef(name.toTermName, d.TypeTree(), d.EmptyTree).withPos(enclosingPosition)
+      d.ValDef(name.toTermName, d.TypeTree(), d.EmptyTree).withPosition
 
     def unapply(tree: Tree): Option[(String, Option[TypeTree])] = tree match {
       case c.ValDef(name, tp, _)  =>
@@ -346,73 +350,73 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
 
   // types
   object TypeIdent extends TypeIdentHelper {
-    def apply(name: String): TypeTree = d.Ident(name.toTypeName).withPos(enclosingPosition)
+    def apply(name: String): TypeTree = d.Ident(name.toTypeName).withPosition
   }
 
   object TypeSelect extends TypeSelectHelper {
-    def apply(qual: Tree, name: String): TypeTree = d.Select(qual, name.toTypeName).withPos(enclosingPosition)
+    def apply(qual: Tree, name: String): TypeTree = d.Select(qual, name.toTypeName).withPosition
   }
 
   object TypeSingleton extends TypeSingletonHelper {
-    def apply(ref: Tree): TypeTree = d.SingletonTypeTree(ref).withPos(enclosingPosition)
+    def apply(ref: Tree): TypeTree = d.SingletonTypeTree(ref).withPosition
   }
 
   object TypeApply extends TypeApplyHelper {
-    def apply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree = d.AppliedTypeTree(tpe, args.toList).withPos(enclosingPosition)
+    def apply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree = d.AppliedTypeTree(tpe, args.toList).withPosition
   }
 
   object TypeApplyInfix extends TypeApplyInfixHelper {
-    def apply(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree = d.InfixOp(lhs, d.Ident(op.toTypeName), rhs).withPos(enclosingPosition)
+    def apply(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree = d.InfixOp(lhs, d.Ident(op.toTypeName), rhs).withPosition
   }
 
   object TypeFunction extends TypeFunctionHelper {
-    def apply(params: Seq[TypeTree], res: TypeTree): TypeTree = d.Function(params.toList, res).withPos(enclosingPosition)
+    def apply(params: Seq[TypeTree], res: TypeTree): TypeTree = d.Function(params.toList, res).withPosition
   }
 
   object TypeTuple extends TypeTupleHelper {
-    def apply(args: Seq[TypeTree]): TypeTree = d.Tuple(args.toList).withPos(enclosingPosition)
+    def apply(args: Seq[TypeTree]): TypeTree = d.Tuple(args.toList).withPosition
   }
 
   object TypeAnd extends TypeAndHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.AndTypeTree(lhs, rhs).withPos(enclosingPosition)
+    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.AndTypeTree(lhs, rhs).withPosition
   }
 
   object TypeOr extends TypeOrHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.OrTypeTree(lhs, rhs).withPos(enclosingPosition)
+    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.OrTypeTree(lhs, rhs).withPosition
   }
 
   object TypeRefine extends TypeRefineHelper {
     def apply(tpe : Option[TypeTree], stats: Seq[Tree]): TypeTree =
-      d.RefinedTypeTree(tpe.getOrElse(d.EmptyTree), stats.toList).withPos(enclosingPosition)
+      d.RefinedTypeTree(tpe.getOrElse(d.EmptyTree), stats.toList).withPosition
   }
 
   object TypeBounds extends TypeBoundsHelper {
     def apply(lo: Option[TypeTree], hi: Option[TypeTree]): TypeTree = {
       require(lo.nonEmpty || hi.nonEmpty)
-      d.TypeBoundsTree(lo.getOrElse(d.EmptyTree), hi.getOrElse(d.EmptyTree)).withPos(enclosingPosition)
+      d.TypeBoundsTree(lo.getOrElse(d.EmptyTree), hi.getOrElse(d.EmptyTree)).withPosition
     }
   }
 
   object TypeRepeated extends TypeRepeatedHelper {
-    def apply(tpe: TypeTree): TypeTree = d.PostfixOp(tpe, d.Ident(nme.raw.STAR)).withPos(enclosingPosition)
+    def apply(tpe: TypeTree): TypeTree = d.PostfixOp(tpe, d.Ident(nme.raw.STAR)).withPosition
   }
 
   object TypeByName extends TypeByNameHelper {
-    def apply(tpe: TypeTree): TypeTree = d.ByNameTypeTree(tpe).withPos(enclosingPosition)
+    def apply(tpe: TypeTree): TypeTree = d.ByNameTypeTree(tpe).withPosition
   }
 
   object TypeAnnotated extends TypeAnnotatedHelper {
     def apply(tpe: TypeTree, annots: Seq[Tree]): TypeTree = {
       require(annots.size > 0)
-      annots.tail.foldRight(d.Annotated(tpe, annots.head).withPos(enclosingPosition)) { (ann, acc) =>
-        d.Annotated(acc, ann).withPos(enclosingPosition)
+      annots.tail.foldRight(d.Annotated(tpe, annots.head).withPosition) { (ann, acc) =>
+        d.Annotated(acc, ann).withPosition
       }
     }
   }
 
   // terms
   object Lit extends LitHelper {
-    def apply(value: Any): Tree = d.Literal(Constant(value)).withPos(enclosingPosition)
+    def apply(value: Any): Tree = d.Literal(Constant(value)).withPosition
     def unapply(tree: Tree): Option[Any] = tree match {
       case c.Literal(Constant(v)) => Some(v)
       case _ => None
@@ -420,21 +424,21 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
   }
 
   object Ident extends IdentHelper {
-    def apply(name: String): Tree = d.Ident(name.toTermName).withPos(enclosingPosition)
+    def apply(name: String): Tree = d.Ident(name.toTermName).withPosition
   }
 
   object Select extends SelectHelper {
-    def apply(qual: Tree, name: String): Tree = d.Select(qual, name.toTermName).withPos(enclosingPosition)
+    def apply(qual: Tree, name: String): Tree = d.Select(qual, name.toTermName).withPosition
   }
 
   object This extends ThisHelper {
-    def apply(qual: String): Tree = d.This(d.Ident(qual.toTypeName)).withPos(enclosingPosition)
-    def apply(qual: Tree): Tree = d.This(qual.asInstanceOf[d.Ident]).withPos(enclosingPosition)
+    def apply(qual: String): Tree = d.This(d.Ident(qual.toTypeName)).withPosition
+    def apply(qual: Tree): Tree = d.This(qual.asInstanceOf[d.Ident]).withPosition
   }
 
   object Super extends SuperHelper {
     def apply(thisp: String, superp: String): Tree =
-      d.Super(d.Ident(thisp.toTypeName), d.Ident(superp.toTypeName)).withPos(enclosingPosition)
+      d.Super(d.Ident(thisp.toTypeName), d.Ident(superp.toTypeName)).withPosition
   }
 
   object Interpolate extends InterpolateHelper {
@@ -453,12 +457,12 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
           thickets :+ Lit(parts.last)
         else thickets
 
-      d.InterpolatedString(prefix.toTermName, segments.toList).withPos(enclosingPosition)
+      d.InterpolatedString(prefix.toTermName, segments.toList).withPosition
     }
   }
 
   object Apply extends ApplyHelper {
-    def apply(fun: Tree, args: Seq[Tree]): Tree = d.Apply(fun, args.toList).withPos(enclosingPosition)
+    def apply(fun: Tree, args: Seq[Tree]): Tree = d.Apply(fun, args.toList).withPosition
     def unapply(tree: Tree): Option[(Tree, Seq[Tree])] = tree match {
       case c.Apply(fun, args) => Some((fun, args))
       case _ => None
@@ -466,7 +470,7 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
   }
 
   object ApplyType extends ApplyTypeHelper {
-    def apply(fun: Tree, args: Seq[TypeTree]): Tree = d.TypeApply(fun, args.toList).withPos(enclosingPosition)
+    def apply(fun: Tree, args: Seq[TypeTree]): Tree = d.TypeApply(fun, args.toList).withPosition
 
     def unapply(tree: Tree): Option[(Tree, Seq[TypeTree])] = tree match {
       case c.TypeApply(fun, args) => Some((fun, args))
@@ -477,19 +481,19 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
   // a + (b, c)  =>  Infix(a, +, Tuple(b, c))
   object Infix extends InfixHelper {
     def apply(lhs: Tree, op: String, rhs: Tree): Tree =
-      d.Apply(d.Select(lhs, op.toTermName), List(rhs)).withPos(enclosingPosition)
+      d.Apply(d.Select(lhs, op.toTermName), List(rhs)).withPosition
   }
 
   object Prefix extends PrefixHelper {
-    def apply(op: String, od: Tree): Tree = d.PrefixOp(d.Ident(op.toTermName), od).withPos(enclosingPosition)
+    def apply(op: String, od: Tree): Tree = d.PrefixOp(d.Ident(op.toTermName), od).withPosition
   }
 
   object Postfix extends PostfixHelper {
-    def apply(od: Tree, op: String): Tree = d.PostfixOp(od, d.Ident(op.toTermName)).withPos(enclosingPosition)
+    def apply(od: Tree, op: String): Tree = d.PostfixOp(od, d.Ident(op.toTermName)).withPosition
   }
 
   object Assign extends AssignHelper {
-    def apply(lhs: Tree, rhs: Tree): Tree = d.Assign(lhs, rhs).withPos(enclosingPosition)
+    def apply(lhs: Tree, rhs: Tree): Tree = d.Assign(lhs, rhs).withPosition
 
     def unapply(tree: Tree): Option[(Tree, Tree)] = tree match {
       case c.Assign(lhs, rhs) => Some((lhs, rhs))
@@ -498,78 +502,78 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
   }
 
   object Return extends ReturnHelper {
-    def apply(expr: Tree): Tree = d.Return(expr, d.EmptyTree).withPos(enclosingPosition)
+    def apply(expr: Tree): Tree = d.Return(expr, d.EmptyTree).withPosition
   }
 
   object Throw extends ThrowHelper {
-    def apply(expr: Tree): Tree = d.Throw(expr).withPos(enclosingPosition)
+    def apply(expr: Tree): Tree = d.Throw(expr).withPosition
   }
 
   object Ascribe extends AscribeHelper {
-    def apply(expr: Tree, tpe: Tree): Tree = d.Typed(expr, tpe).withPos(enclosingPosition)
+    def apply(expr: Tree, tpe: Tree): Tree = d.Typed(expr, tpe).withPosition
   }
 
   object Annotated extends AnnotatedHelper {
     def apply(expr: Tree, annots: Seq[Tree]): Tree = {
       require(annots.size > 0)
-      annots.tail.foldRight(d.Annotated(expr, annots.head).withPos(enclosingPosition)) { (ann, acc) =>
-        d.Annotated(acc, ann).withPos(enclosingPosition)
+      annots.tail.foldRight(d.Annotated(expr, annots.head).withPosition) { (ann, acc) =>
+        d.Annotated(acc, ann).withPosition
       }
     }
   }
 
   object Tuple extends TupleHelper {
-    def apply(args: Seq[Tree]): Tree = d.Tuple(args.toList).withPos(enclosingPosition)
+    def apply(args: Seq[Tree]): Tree = d.Tuple(args.toList).withPosition
   }
 
   object Block extends BlockHelper {
     def apply(stats: Seq[Tree]): Tree = {
       if (stats.size == 0)
-        d.Block(stats.toList, d.EmptyTree).withPos(enclosingPosition)
+        d.Block(stats.toList, d.EmptyTree).withPosition
       else
-        d.Block(stats.init.toList, stats.last).withPos(enclosingPosition)
+        d.Block(stats.init.toList, stats.last).withPosition
     }
   }
 
   object If extends IfHelper {
     def apply(cond: Tree, thenp: Tree, elsep: Option[Tree]): Tree =
-      d.If(cond, thenp, elsep.getOrElse(d.EmptyTree)).withPos(enclosingPosition)
+      d.If(cond, thenp, elsep.getOrElse(d.EmptyTree)).withPosition
   }
 
   object Match extends MatchHelper {
     def apply(expr: Tree, cases: Seq[Tree]): Tree =
-      d.Match(expr, cases.toList.asInstanceOf[List[d.CaseDef]]).withPos(enclosingPosition)
+      d.Match(expr, cases.toList.asInstanceOf[List[d.CaseDef]]).withPosition
   }
 
   object Case extends CaseHelper {
     def apply(pat: Tree, cond: Option[Tree], body: Tree): Tree =
-      d.CaseDef(pat, cond.getOrElse(d.EmptyTree), body).withPos(enclosingPosition)
+      d.CaseDef(pat, cond.getOrElse(d.EmptyTree), body).withPosition
   }
 
   object Try extends TryHelper {
     def apply(expr: Tree, cases: Seq[Tree], finallyp: Option[Tree]): Tree =
-      d.Try(expr, cases.toList.asInstanceOf[List[d.CaseDef]], finallyp.getOrElse(d.EmptyTree)).withPos(enclosingPosition)
+      d.Try(expr, cases.toList.asInstanceOf[List[d.CaseDef]], finallyp.getOrElse(d.EmptyTree)).withPosition
 
     def apply(expr: Tree, handler: Tree, finallyp: Option[Tree]): Tree =
-      d.ParsedTry(expr, handler, finallyp.getOrElse(d.EmptyTree)).withPos(enclosingPosition)
+      d.ParsedTry(expr, handler, finallyp.getOrElse(d.EmptyTree)).withPosition
   }
 
   object Function extends FunctionHelper {
     def apply(params: Seq[Tree], body: Tree): Tree =
-      d.Function(params.toList, body).withPos(enclosingPosition)
+      d.Function(params.toList, body).withPosition
   }
 
   object PartialFunction extends PartialFunctionHelper {
     def apply(cases: Seq[Tree]): Tree =
-      d.Match(d.Thicket(Nil), cases.toList.asInstanceOf[List[d.CaseDef]]).withPos(enclosingPosition)
+      d.Match(d.Thicket(Nil), cases.toList.asInstanceOf[List[d.CaseDef]]).withPosition
   }
 
   object While extends WhileHelper {
-    def apply(expr: Tree, body: Tree): Tree = d.WhileDo(expr, body).withPos(enclosingPosition)
+    def apply(expr: Tree, body: Tree): Tree = d.WhileDo(expr, body).withPosition
   }
 
   object DoWhile extends DoWhileHelper {
-    def apply(body: Tree, expr: Tree): Tree = d.DoWhile(body, expr).withPos(enclosingPosition)
+    def apply(body: Tree, expr: Tree): Tree = d.DoWhile(body, expr).withPosition
   }
 
   object For extends ForHelper {
@@ -594,56 +598,56 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
 
   // can be InitCall or AnonymClass
   object New extends NewHelper {
-    def apply(tpe: Tree): Tree = d.New(tpe).withPos(enclosingPosition)
+    def apply(tpe: Tree): Tree = d.New(tpe).withPosition
   }
 
   object Named extends NamedHelper {
     def apply(name: String, expr: Tree): Tree =
-      d.NamedArg(name.toTermName, expr).withPos(enclosingPosition)
+      d.NamedArg(name.toTermName, expr).withPosition
   }
 
   object Repeated extends RepeatedHelper {
     def apply(expr: Tree): Tree =
-      d.Typed(expr, d.Ident(tpnme.WILDCARD_STAR)).withPos(enclosingPosition)
+      d.Typed(expr, d.Ident(tpnme.WILDCARD_STAR)).withPosition
   }
 
   // patterns
   object Bind extends BindHelper {
     def apply(name: String, expr: Tree): Tree =
-      d.Bind(name.toTermName, expr).withPos(enclosingPosition)
+      d.Bind(name.toTermName, expr).withPosition
   }
 
   object Alternative extends AlternativeHelper {
     def apply(lhs: Tree, rhs: Tree): Tree =
-      d.Alternative(List(lhs, rhs)).withPos(enclosingPosition)
+      d.Alternative(List(lhs, rhs)).withPosition
   }
 
   // importees
   object Import extends ImportHelper {
     def apply(items: Seq[Tree]): Tree =
       if (items.size == 1)
-        items(0).withPos(enclosingPosition)
+        items(0).withPosition
       else
-        d.Thicket(items.toList).withPos(enclosingPosition)
+        d.Thicket(items.toList).withPosition
   }
 
   object ImportItem extends ImportItemHelper {
     def apply(ref: Tree, importees: Seq[Tree]): Tree =
-      d.Import(ref, importees.toList).withPos(enclosingPosition)
+      d.Import(ref, importees.toList).withPosition
   }
 
   object ImportName extends ImportNameHelper {
-    def apply(name: String): Tree = d.Ident(name.toTermName).withPos(enclosingPosition)
+    def apply(name: String): Tree = d.Ident(name.toTermName).withPosition
   }
 
   object ImportRename extends ImportRenameHelper {
     def apply(from: String, to: String): Tree =
-      d.Thicket(d.Ident(from.toTermName), d.Ident(to.toTermName)).withPos(enclosingPosition)
+      d.Thicket(d.Ident(from.toTermName), d.Ident(to.toTermName)).withPosition
   }
 
   object ImportHide extends ImportHideHelper {
     def apply(name: String): Tree =
-      d.Thicket(d.Ident(name.toTermName), d.Ident(nme.WILDCARD)).withPos(enclosingPosition)
+      d.Thicket(d.Ident(name.toTermName), d.Ident(nme.WILDCARD)).withPosition
   }
 
   // modifiers

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -137,7 +137,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
       val constr = d.DefDef(nme.CONSTRUCTOR, Nil, Nil, d.TypeTree(), d.EmptyTree)
       val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
       val templ = d.Template(constr, parents.toList, self, stats)
-      d.ModuleDef(name.toTermName, templ).withMods(fromMods(mods))
+      d.ModuleDef(name.toTermName, templ).withMods(fromMods(mods)).withPos(enclosingPosition)
     }
 
     def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree])] = tree match {
@@ -161,7 +161,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
       val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
       val templ = d.Template(constr, parents.toList, self, stats)
-      d.TypeDef(name.toTypeName, templ).withMods(fromMods(mods))
+      d.TypeDef(name.toTypeName, templ).withMods(fromMods(mods)).withPos(enclosingPosition)
     }
 
     def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])] = tree match {
@@ -183,13 +183,13 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
     def apply(parents: Seq[Tree], selfOpt: Option[Tree], stats: Seq[Tree]): Tree = {
       val init = d.DefDef(nme.CONSTRUCTOR, List(), List(), d.TypeTree(), d.EmptyTree)
       val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
-      d.Template(init, parents.toList, self, stats)
+      d.Template(init, parents.toList, self, stats).withPos(enclosingPosition)
     }
   }
 
   object Trait extends TraitHelper {
     def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], ctor: Option[Tree], parents: Seq[Tree], self: Option[Tree], stats: Seq[Tree]): Tree =
-      Class(mods, name, tparams, ctor, parents, self, stats).asInstanceOf[d.TypeDef].withFlags(Flags.Trait)
+      Class(mods, name, tparams, ctor, parents, self, stats).asInstanceOf[d.TypeDef].withFlags(Flags.Trait).withPos(enclosingPosition)
 
     def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])] =
       if (!tree.isInstanceOf[d.TypeDef]) return None
@@ -207,7 +207,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
       val body =
         if (tparams.size == 0) tbounds
         else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], tbounds)
-      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods))
+      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPos(enclosingPosition)
     }
   }
 
@@ -216,7 +216,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
       val body =
         if (tparams.size == 0) rhs
         else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], rhs)
-      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods))
+      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)) //not leaf
     }
   }
 
@@ -224,7 +224,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
     def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: Option[TypeTree], rhs: Tree): Tree = {
       val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
       val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
-      d.DefDef(name.toTermName, types, params, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods))
+      d.DefDef(name.toTermName, types, params, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)) //not leaf
     }
   }
 
@@ -232,53 +232,53 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
     def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: TypeTree): Tree = {
       val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
       val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
-      d.DefDef(name.toTermName, types, params, tpe, d.EmptyTree).withMods(fromMods(mods))
+      d.DefDef(name.toTermName, types, params, tpe, d.EmptyTree).withMods(fromMods(mods)) //not leaf
     }
   }
 
   object ValDef extends ValDefHelper {
     def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods))
+      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)) //not leaf
 
     def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods), List(lhs), tpe.getOrElse(d.TypeTree()), rhs)
+      d.PatDef(fromMods(mods), List(lhs), tpe.getOrElse(d.TypeTree()), rhs) //not leaf
 
     def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods), pats.toList, tpe.getOrElse(d.TypeTree()), rhs)
+      d.PatDef(fromMods(mods), pats.toList, tpe.getOrElse(d.TypeTree()), rhs) //not leaf
   }
 
   object ValDecl extends ValDeclHelper {
     def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods))
+      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods)) //not leaf
 
     def apply(mods: Seq[Tree], vals: Seq[String], tpe: TypeTree): Tree =
-      d.PatDef(fromMods(mods), vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree)
+      d.PatDef(fromMods(mods), vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree) //not leaf
   }
 
   object VarDef extends VarDefHelper {
     def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods) | Flags.Mutable)
+      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods) | Flags.Mutable) //not leaf
 
     def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, List(lhs), tpe.getOrElse(d.TypeTree()), rhs)
+      d.PatDef(fromMods(mods) | Flags.Mutable, List(lhs), tpe.getOrElse(d.TypeTree()), rhs) //not leaf
 
     def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, pats.toList, tpe.getOrElse(d.TypeTree()), rhs)
+      d.PatDef(fromMods(mods) | Flags.Mutable, pats.toList, tpe.getOrElse(d.TypeTree()), rhs) //not leaf
   }
 
   object VarDecl extends VarDeclHelper {
     def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods) | Flags.Mutable)
+      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods) | Flags.Mutable) //not leaf
 
     def apply(mods: Seq[Tree], vals: Seq[String], tpe: TypeTree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree)
+      d.PatDef(fromMods(mods) | Flags.Mutable, vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree) //not leaf
   }
 
   object PrimaryCtor extends PrimaryCtorHelper {
     // Dummy trees to retrofit Dotty AST
     private case class PrimaryCtorTree(mods: Seq[Tree], paramss: Seq[Seq[Tree]]) extends d.Tree
 
-    def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]]): Tree = PrimaryCtorTree(mods, paramss)
+    def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]]): Tree = PrimaryCtorTree(mods, paramss).withPos(enclosingPosition)
 
     def unapply(tree: Tree): Option[(Seq[Tree], Seq[Seq[Tree]])] = tree match {
       case PrimaryCtorTree(mods, paramss) => Some((mods, paramss))
@@ -288,7 +288,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   object SecondaryCtor extends SecondaryCtorHelper {
     def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]], rhs: Tree): Tree =
-      DefDef(mods, nme.CONSTRUCTOR.toString, Nil, paramss, Some(d.TypeTree()), rhs)
+      DefDef(mods, nme.CONSTRUCTOR.toString, Nil, paramss, Some(d.TypeTree()), rhs) //not leaf
   }
 
   // qual.T[A, B](x, y)(z)
@@ -296,13 +296,13 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
     def apply(qual: Option[Tree], name: String, tparams: Seq[TypeTree], argss: Seq[Seq[Tree]]): Tree = {
       val select = if (qual.isEmpty) d.Ident(name.toTermName) else d.Select(qual.get, name.toTypeName)
       val fun = if (tparams.size == 0) select else TypeApply(select, tparams.toList)
-      ApplySeq(fun, argss)
+      ApplySeq(fun, argss).withPos(enclosingPosition)
     }
   }
 
   object Param extends ParamHelper {
     def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], default: Option[Tree]): Tree = {
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), getOrEmpty(default)).withMods(fromMods(mods)).withFlags(Flags.TermParam)
+      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), getOrEmpty(default)).withMods(fromMods(mods)).withFlags(Flags.TermParam).withPos(enclosingPosition)
     }
 
     def unapply(tree: Tree): Option[(Seq[Tree], String, Option[TypeTree], Option[Tree])] = tree match {
@@ -325,16 +325,16 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
         if (tparams.size == 0) inner
         else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], inner)
 
-      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods))
+      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPos(enclosingPosition)
     }
   }
 
   object Self extends SelfHelper {
     def apply(name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree)
+      d.ValDef(name.toTermName, tpe, d.EmptyTree) //not leaf
 
     def apply(name: String): Tree =
-      d.ValDef(name.toTermName, d.TypeTree(), d.EmptyTree)
+      d.ValDef(name.toTermName, d.TypeTree(), d.EmptyTree).withPos(enclosingPosition)
 
     def unapply(tree: Tree): Option[(String, Option[TypeTree])] = tree match {
       case c.ValDef(name, tp, _)  =>
@@ -346,66 +346,66 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   // types
   object TypeIdent extends TypeIdentHelper {
-    def apply(name: String): TypeTree = d.Ident(name.toTypeName)
+    def apply(name: String): TypeTree = d.Ident(name.toTypeName).withPos(enclosingPosition)
   }
 
   object TypeSelect extends TypeSelectHelper {
-    def apply(qual: Tree, name: String): TypeTree = d.Select(qual, name.toTypeName)
+    def apply(qual: Tree, name: String): TypeTree = d.Select(qual, name.toTypeName) //not leaf
   }
 
   object TypeSingleton extends TypeSingletonHelper {
-    def apply(ref: Tree): TypeTree = d.SingletonTypeTree(ref)
+    def apply(ref: Tree): TypeTree = d.SingletonTypeTree(ref) //not leaf
   }
 
   object TypeApply extends TypeApplyHelper {
-    def apply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree = d.AppliedTypeTree(tpe, args.toList)
+    def apply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree = d.AppliedTypeTree(tpe, args.toList) //not leaf
   }
 
   object TypeApplyInfix extends TypeApplyInfixHelper {
-    def apply(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree = d.InfixOp(lhs, d.Ident(op.toTypeName), rhs)
+    def apply(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree = d.InfixOp(lhs, d.Ident(op.toTypeName), rhs) //not leaf
   }
 
   object TypeFunction extends TypeFunctionHelper {
-    def apply(params: Seq[TypeTree], res: TypeTree): TypeTree = d.Function(params.toList, res)
+    def apply(params: Seq[TypeTree], res: TypeTree): TypeTree = d.Function(params.toList, res) //not leaf
   }
 
   object TypeTuple extends TypeTupleHelper {
-    def apply(args: Seq[TypeTree]): TypeTree = d.Tuple(args.toList)
+    def apply(args: Seq[TypeTree]): TypeTree = d.Tuple(args.toList).withPos(enclosingPosition)
   }
 
   object TypeAnd extends TypeAndHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.AndTypeTree(lhs, rhs)
+    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.AndTypeTree(lhs, rhs) //not leaf
   }
 
   object TypeOr extends TypeOrHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.OrTypeTree(lhs, rhs)
+    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.OrTypeTree(lhs, rhs) //not leaf
   }
 
   object TypeRefine extends TypeRefineHelper {
     def apply(tpe : Option[TypeTree], stats: Seq[Tree]): TypeTree =
-      d.RefinedTypeTree(tpe.getOrElse(d.EmptyTree), stats.toList)
+      d.RefinedTypeTree(tpe.getOrElse(d.EmptyTree), stats.toList).withPos(enclosingPosition)
   }
 
   object TypeBounds extends TypeBoundsHelper {
     def apply(lo: Option[TypeTree], hi: Option[TypeTree]): TypeTree = {
       require(lo.nonEmpty || hi.nonEmpty)
-      d.TypeBoundsTree(lo.getOrElse(d.EmptyTree), hi.getOrElse(d.EmptyTree))
+      d.TypeBoundsTree(lo.getOrElse(d.EmptyTree), hi.getOrElse(d.EmptyTree)) //not leaf
     }
   }
 
   object TypeRepeated extends TypeRepeatedHelper {
-    def apply(tpe: TypeTree): TypeTree = d.PostfixOp(tpe, d.Ident(nme.raw.STAR))
+    def apply(tpe: TypeTree): TypeTree = d.PostfixOp(tpe, d.Ident(nme.raw.STAR)) //not leaf
   }
 
   object TypeByName extends TypeByNameHelper {
-    def apply(tpe: TypeTree): TypeTree = d.ByNameTypeTree(tpe)
+    def apply(tpe: TypeTree): TypeTree = d.ByNameTypeTree(tpe) //not leaf
   }
 
   object TypeAnnotated extends TypeAnnotatedHelper {
     def apply(tpe: TypeTree, annots: Seq[Tree]): TypeTree = {
       require(annots.size > 0)
-      annots.tail.foldRight(d.Annotated(tpe, annots.head)) { (ann, acc) =>
-        d.Annotated(acc, ann)
+      annots.tail.foldRight(d.Annotated(tpe, annots.head)/*not leaf*/) { (ann, acc) =>
+        d.Annotated(acc, ann) //not leaf
       }
     }
   }
@@ -424,17 +424,17 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object Select extends SelectHelper {
-    def apply(qual: Tree, name: String): Tree = d.Select(qual, name.toTermName)
+    def apply(qual: Tree, name: String): Tree = d.Select(qual, name.toTermName) //not leaf
   }
 
   object This extends ThisHelper {
-    def apply(qual: String): Tree = d.This(d.Ident(qual.toTypeName))
-    def apply(qual: Tree): Tree = d.This(qual.asInstanceOf[d.Ident])
+    def apply(qual: String): Tree = d.This(d.Ident(qual.toTypeName)).withPos(enclosingPosition)
+    def apply(qual: Tree): Tree = d.This(qual.asInstanceOf[d.Ident]) //not leaf
   }
 
   object Super extends SuperHelper {
     def apply(thisp: String, superp: String): Tree =
-      d.Super(d.Ident(thisp.toTypeName), d.Ident(superp.toTypeName))
+      d.Super(d.Ident(thisp.toTypeName), d.Ident(superp.toTypeName)).withPos(enclosingPosition)
   }
 
   object Interpolate extends InterpolateHelper {
@@ -453,12 +453,12 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
           thickets :+ Lit(parts.last)
         else thickets
 
-      d.InterpolatedString(prefix.toTermName, segments.toList)
+      d.InterpolatedString(prefix.toTermName, segments.toList).withPos(enclosingPosition)
     }
   }
 
   object Apply extends ApplyHelper {
-    def apply(fun: Tree, args: Seq[Tree]): Tree = d.Apply(fun, args.toList)
+    def apply(fun: Tree, args: Seq[Tree]): Tree = d.Apply(fun, args.toList) //not leaf
     def unapply(tree: Tree): Option[(Tree, Seq[Tree])] = tree match {
       case c.Apply(fun, args) => Some((fun, args))
       case _ => None
@@ -466,7 +466,7 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object ApplyType extends ApplyTypeHelper {
-    def apply(fun: Tree, args: Seq[TypeTree]): Tree = d.TypeApply(fun, args.toList)
+    def apply(fun: Tree, args: Seq[TypeTree]): Tree = d.TypeApply(fun, args.toList) //not leaf
 
     def unapply(tree: Tree): Option[(Tree, Seq[TypeTree])] = tree match {
       case c.TypeApply(fun, args) => Some((fun, args))
@@ -476,20 +476,20 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   // a + (b, c)  =>  Infix(a, +, Tuple(b, c))
   object Infix extends InfixHelper {
-    def apply(lhs: Tree, op: String, rhs: Tree): Tree =
+    def apply(lhs: Tree, op: String, rhs: Tree): Tree = //not leaf
       d.Apply(d.Select(lhs, op.toTermName), List(rhs))
   }
 
   object Prefix extends PrefixHelper {
-    def apply(op: String, od: Tree): Tree = d.PrefixOp(d.Ident(op.toTermName), od)
+    def apply(op: String, od: Tree): Tree = d.PrefixOp(d.Ident(op.toTermName), od) //not leaf
   }
 
   object Postfix extends PostfixHelper {
-    def apply(od: Tree, op: String): Tree = d.PostfixOp(od, d.Ident(op.toTermName))
+    def apply(od: Tree, op: String): Tree = d.PostfixOp(od, d.Ident(op.toTermName)) //not leaf
   }
 
   object Assign extends AssignHelper {
-    def apply(lhs: Tree, rhs: Tree): Tree = d.Assign(lhs, rhs)
+    def apply(lhs: Tree, rhs: Tree): Tree = d.Assign(lhs, rhs) //not leaf
 
     def unapply(tree: Tree): Option[(Tree, Tree)] = tree match {
       case c.Assign(lhs, rhs) => Some((lhs, rhs))
@@ -498,78 +498,78 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
   }
 
   object Return extends ReturnHelper {
-    def apply(expr: Tree): Tree = d.Return(expr, d.EmptyTree)
+    def apply(expr: Tree): Tree = d.Return(expr, d.EmptyTree) //not leaf
   }
 
   object Throw extends ThrowHelper {
-    def apply(expr: Tree): Tree = d.Throw(expr)
+    def apply(expr: Tree): Tree = d.Throw(expr) //not leaf
   }
 
   object Ascribe extends AscribeHelper {
-    def apply(expr: Tree, tpe: Tree): Tree = d.Typed(expr, tpe)
+    def apply(expr: Tree, tpe: Tree): Tree = d.Typed(expr, tpe) //not leaf
   }
 
   object Annotated extends AnnotatedHelper {
     def apply(expr: Tree, annots: Seq[Tree]): Tree = {
       require(annots.size > 0)
-      annots.tail.foldRight(d.Annotated(expr, annots.head)) { (ann, acc) =>
-        d.Annotated(acc, ann)
+      annots.tail.foldRight(d.Annotated(expr, annots.head)/*not leaf*/) { (ann, acc) =>
+        d.Annotated(acc, ann) //not leaf
       }
     }
   }
 
   object Tuple extends TupleHelper {
-    def apply(args: Seq[Tree]): Tree = d.Tuple(args.toList)
+    def apply(args: Seq[Tree]): Tree = d.Tuple(args.toList).withPos(enclosingPosition)
   }
 
   object Block extends BlockHelper {
     def apply(stats: Seq[Tree]): Tree = {
       if (stats.size == 0)
-        d.Block(stats.toList, d.EmptyTree)
+        d.Block(stats.toList, d.EmptyTree).withPos(enclosingPosition)
       else
-        d.Block(stats.init.toList, stats.last)
+        d.Block(stats.init.toList, stats.last) //not leaf
     }
   }
 
   object If extends IfHelper {
     def apply(cond: Tree, thenp: Tree, elsep: Option[Tree]): Tree =
-      d.If(cond, thenp, elsep.getOrElse(d.EmptyTree))
+      d.If(cond, thenp, elsep.getOrElse(d.EmptyTree)) //not leaf
   }
 
   object Match extends MatchHelper {
     def apply(expr: Tree, cases: Seq[Tree]): Tree =
-      d.Match(expr, cases.toList.asInstanceOf[List[d.CaseDef]])
+      d.Match(expr, cases.toList.asInstanceOf[List[d.CaseDef]]) //not leaf
   }
 
   object Case extends CaseHelper {
     def apply(pat: Tree, cond: Option[Tree], body: Tree): Tree =
-      d.CaseDef(pat, cond.getOrElse(d.EmptyTree), body)
+      d.CaseDef(pat, cond.getOrElse(d.EmptyTree), body) //not leaf
   }
 
   object Try extends TryHelper {
     def apply(expr: Tree, cases: Seq[Tree], finallyp: Option[Tree]): Tree =
-      d.Try(expr, cases.toList.asInstanceOf[List[d.CaseDef]], finallyp.getOrElse(d.EmptyTree))
+      d.Try(expr, cases.toList.asInstanceOf[List[d.CaseDef]], finallyp.getOrElse(d.EmptyTree)) //not leaf
 
     def apply(expr: Tree, handler: Tree, finallyp: Option[Tree]): Tree =
-      d.ParsedTry(expr, handler, finallyp.getOrElse(d.EmptyTree))
+      d.ParsedTry(expr, handler, finallyp.getOrElse(d.EmptyTree)) //not leaf
   }
 
   object Function extends FunctionHelper {
     def apply(params: Seq[Tree], body: Tree): Tree =
-      d.Function(params.toList, body)
+      d.Function(params.toList, body) //not leaf
   }
 
   object PartialFunction extends PartialFunctionHelper {
     def apply(cases: Seq[Tree]): Tree =
-      d.Match(d.Thicket(Nil), cases.toList.asInstanceOf[List[d.CaseDef]])
+      d.Match(d.Thicket(Nil), cases.toList.asInstanceOf[List[d.CaseDef]]).withPos(enclosingPosition)
   }
 
   object While extends WhileHelper {
-    def apply(expr: Tree, body: Tree): Tree = d.WhileDo(expr, body)
+    def apply(expr: Tree, body: Tree): Tree = d.WhileDo(expr, body) //not leaf
   }
 
   object DoWhile extends DoWhileHelper {
-    def apply(body: Tree, expr: Tree): Tree = d.DoWhile(body, expr)
+    def apply(body: Tree, expr: Tree): Tree = d.DoWhile(body, expr) //not leaf
   }
 
   object For extends ForHelper {
@@ -594,56 +594,56 @@ class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit 
 
   // can be InitCall or AnonymClass
   object New extends NewHelper {
-    def apply(tpe: Tree): Tree = d.New(tpe)
+    def apply(tpe: Tree): Tree = d.New(tpe) //not leaf
   }
 
   object Named extends NamedHelper {
     def apply(name: String, expr: Tree): Tree =
-      d.NamedArg(name.toTermName, expr)
+      d.NamedArg(name.toTermName, expr) //not leaf
   }
 
   object Repeated extends RepeatedHelper {
     def apply(expr: Tree): Tree =
-      d.Typed(expr, d.Ident(tpnme.WILDCARD_STAR))
+      d.Typed(expr, d.Ident(tpnme.WILDCARD_STAR)) //not leaf
   }
 
   // patterns
   object Bind extends BindHelper {
     def apply(name: String, expr: Tree): Tree =
-      d.Bind(name.toTermName, expr)
+      d.Bind(name.toTermName, expr) //not leaf
   }
 
   object Alternative extends AlternativeHelper {
     def apply(lhs: Tree, rhs: Tree): Tree =
-      d.Alternative(List(lhs, rhs))
+      d.Alternative(List(lhs, rhs)) //not leaf
   }
 
   // importees
   object Import extends ImportHelper {
     def apply(items: Seq[Tree]): Tree =
       if (items.size == 1)
-        items(0)
+        items(0).withPos(enclosingPosition)
       else
-        d.Thicket(items.toList)
+        d.Thicket(items.toList).withPos(enclosingPosition)
   }
 
   object ImportItem extends ImportItemHelper {
     def apply(ref: Tree, importees: Seq[Tree]): Tree =
-      d.Import(ref, importees.toList)
+      d.Import(ref, importees.toList) //not leaf
   }
 
   object ImportName extends ImportNameHelper {
-    def apply(name: String): Tree = d.Ident(name.toTermName)
+    def apply(name: String): Tree = d.Ident(name.toTermName).withPos(enclosingPosition)
   }
 
   object ImportRename extends ImportRenameHelper {
     def apply(from: String, to: String): Tree =
-      d.Thicket(d.Ident(from.toTermName), d.Ident(to.toTermName))
+      d.Thicket(d.Ident(from.toTermName), d.Ident(to.toTermName)).withPos(enclosingPosition)
   }
 
   object ImportHide extends ImportHideHelper {
     def apply(name: String): Tree =
-      d.Thicket(d.Ident(name.toTermName), d.Ident(nme.WILDCARD))
+      d.Thicket(d.Ident(name.toTermName), d.Ident(nme.WILDCARD)).withPos(enclosingPosition)
   }
 
   // modifiers

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -17,7 +17,7 @@ import Positions.Position
 
 import scala.collection.mutable.ListBuffer
 
-class DottyToolbox(enclosingPosition: Position = Positions.NoPosition)(implicit ctx: Context) extends Toolbox {
+class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends Toolbox {
   type Tree = d.Tree
   type TypeTree = d.Tree
   type Type = Types.Type

--- a/src/main/scala/gestalt/dotty/Expander.scala
+++ b/src/main/scala/gestalt/dotty/Expander.scala
@@ -63,7 +63,7 @@ object Expander {
           val mods1 = mdef.mods.withAnnotations(mdef.mods.annotations.filter(_ ne ann))
           mdef.withMods(mods1)
         }
-        val result = impl.invoke(null, new DottyToolbox(), ann, expandee).asInstanceOf[untpd.Tree]
+        val result = impl.invoke(null, new DottyToolbox(ann.pos), ann, expandee).asInstanceOf[untpd.Tree]
         Some(result)
       case _ =>
         None
@@ -82,7 +82,7 @@ object Expander {
       val impl = moduleClass.getDeclaredMethods().find(_.getName == method.toString).get
       impl.setAccessible(true)
 
-      val trees  = new DottyToolbox() :: prefix :: targs ++ argss.flatten
+      val trees  = new DottyToolbox(tree.pos) :: prefix :: targs ++ argss.flatten
       impl.invoke(null, trees: _*).asInstanceOf[untpd.Tree]
     case _ =>
       tree

--- a/src/main/scala/gestalt/dotty/Expander.scala
+++ b/src/main/scala/gestalt/dotty/Expander.scala
@@ -43,7 +43,7 @@ object Expander {
         (name.toString, parts, pats)
     }
     val strs = for(Literal(Constant(v: String)) <- parts) yield v
-    expand(new DottyToolbox())(tag, strs, args, !isTerm)
+    expand(new DottyToolbox(tree.pos))(tag, strs, args, !isTerm)
   }
 
   /** Expand annotation macros */


### PR DESCRIPTION
-  Fix for #16 : Added `enclosingPosition` to DottyToolbox populating it in both expansion of quasiquotes as well as def and annotation macros. So it won't fail when writing the macro nor when it is expanded. Added `.withPos` to all AST elements.
Initially I added the `.withPos` to only leaf nodes ( @liufengyun, as you suggested). However there were a lot of both leaves, and non-leaves, and it was hard in cases to tell whether a node could be a leaf (is any of Option[Tree] non-empty). To avoid reduce complexity and avoid confusion, I added `.withPos` to all AST elements.
- Fix for #17 : In `Quote.lift` literal now generates the code of creating the literal not the literal itself.
- Also added "meta-types" to all the methods and vals. 
If Trees had a type parameter that should the type of code generated by it. I.e. `t.Lit("a")` would be `t.Tree[String]`. There already this kind of comment for `lift` method. The "meta-types" were useful for me, hopefully, they are useful for others.
- To avoid regression also fixed the issues where the "meta-type" was not matching the signatures of `Toolbox` methods. Places where there is not an obvious fix are marked with  "FIXME"
- Added tests for #16 and #17 for both annotation and def macros (quasiquotes are implicitly tested in both).