### PR TITLE
Def macros: support for implicit def

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -35,6 +35,15 @@ object ImplicitsForNumbers {
   }
 }
 
+object ImplicitBigInt {
+  implicit inline def string2BigInt(s: String): BigInt = meta {
+    val q"${str: String}" = s
+    val bigInt = BigInt(str)
+    val bytes = bigInt.toByteArray
+    q"BigInt(3)"
+  }
+}
+
 object scope {
   inline def is[T](a: Any): Boolean = meta {
     q"$a.isInstanceOf[$T]"

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -40,7 +40,7 @@ object ImplicitBigInt {
     val q"${str: String}" = s
     val bigInt = BigInt(str)
     val bytes = bigInt.toByteArray
-    q"BigInt(3)"
+    q"BigInt($bytes)"
   }
 }
 

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -39,8 +39,9 @@ object ImplicitBigInt {
   implicit inline def string2BigInt(s: String): BigInt = meta {
     val q"${str: String}" = s
     val bigInt = BigInt(str)
-    val bytes = bigInt.toByteArray
-    q"BigInt($bytes)"
+    val bytes = bigInt.toByteArray.toVector
+    val literals = bytes.map(toolbox.Lit.apply)
+    q"BigInt(Array[Byte](..$literals))"
   }
 }
 

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -37,7 +37,7 @@ object ImplicitsForNumbers {
 
 object ImplicitBigInt {
   implicit inline def string2BigInt(s: String): BigInt = meta {
-    val q"${toolbox.Lit(str: String)}" = s
+    val toolbox.Lit(str: String) = s
     val bigInt = BigInt(str)
     val radix = Character.MAX_RADIX
     val compressedString = bigInt.toString(radix)

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -37,11 +37,11 @@ object ImplicitsForNumbers {
 
 object ImplicitBigInt {
   implicit inline def string2BigInt(s: String): BigInt = meta {
-    val q"${str: String}" = s
+    val q"${toolbox.Lit(str: String)}" = s
     val bigInt = BigInt(str)
-    val bytes = bigInt.toByteArray.toVector
-    val literals = bytes.map(toolbox.Lit.apply)
-    q"BigInt(Array[Byte](..$literals))"
+    val radix = Character.MAX_RADIX
+    val compressedString = bigInt.toString(radix)
+    q"BigInt(${toolbox.Lit(compressedString)},${toolbox.Lit(radix)})"
   }
 }
 

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -81,6 +81,11 @@ class DefMacroTest extends TestSuite {
     assert(!scope.both[String, List[Int]]("hello"))
   }
 
+  test("explicit big int"){
+    import ImplicitBigInt._
+    assert(string2BigInt("3").modPow(exp = 2, 4) == BigInt(1))
+  }
+
   test("implict big int"){
     import ImplicitBigInt._
     assert("3".modPow(exp = 2, 4) == BigInt(1))

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -81,6 +81,11 @@ class DefMacroTest extends TestSuite {
     assert(!scope.both[String, List[Int]]("hello"))
   }
 
+  test("implict big int"){
+    import ImplicitBigInt._
+    assert("3".modPow(exp = 2, 4) == BigInt(1))
+  }
+
   test("constant quasiqoutes"){
     assert(trees.five() == 5)
     assert(trees.some3() == Some(3))

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -83,12 +83,13 @@ class DefMacroTest extends TestSuite {
 
   test("explicit big int"){
     import ImplicitBigInt._
-    assert(string2BigInt("3").modPow(exp = 2, 4) == BigInt(1))
+    assert(string2BigInt("19") == BigInt(19))
+    assert(string2BigInt("19").modPow(exp = 2, 4) == BigInt(1))
   }
 
   test("implict big int"){
     import ImplicitBigInt._
-    assert("3".modPow(exp = 2, 4) == BigInt(1))
+    assert("19".modPow(exp = 2, 4) == BigInt(1))
   }
 
   test("constant quasiqoutes"){

--- a/src/main/scala/gestalt/dotty/Expander.scala
+++ b/src/main/scala/gestalt/dotty/Expander.scala
@@ -30,7 +30,7 @@ object Expander {
   private object MethodSelect {
     def unapply(tree: untpd.Tree): Option[(untpd.Tree, Name)] = tree match {
       case Select(prefix, method) => Some((prefix, method))
-      case Ident(method) => Some((untpd.EmptyTree, method))
+      case Ident(method) => Some((null, method))
       case _ => None
     }
   }


### PR DESCRIPTION
- Added a test macro of adding BigInt methods to String. It also compresses the representation string to the highest possible radix to save constant size.
- Handling the case where prefix is not specified. Passing a `prefix=null` in this case.
- Added a warning when def macros fails to expand for easier debugging.