### PR TITLE
move quasiquote test to macro project

### DIFF
--- a/macros/src/test/scala/gestalt/macros/Driver.scala
+++ b/macros/src/test/scala/gestalt/macros/Driver.scala
@@ -7,6 +7,7 @@ object Driver {
     // setup tests
     new AnnotationMacroTest
     new DefMacroTest
+    new QuasiquoteTest
 
     var success = false
     var total = 0

--- a/macros/src/test/scala/gestalt/macros/QuasiquoteTest.scala
+++ b/macros/src/test/scala/gestalt/macros/QuasiquoteTest.scala
@@ -1,9 +1,30 @@
-package scala.gestalt
-
 import scala.collection.immutable.Seq
-import org.scalatest.FunSuite
 
-class QuasiquoteSuite extends FunSuite {
+import dotty.tools._
+import dotc.core.Contexts._
+
+import scala.gestalt._
+import dotty.DottyToolbox
+
+class QuasiquoteTest extends TestSuite {
+  val context: Context = {
+    val base = new ContextBase {}
+    val ctx = base.initialCtx.fresh
+    ctx.setSetting(ctx.settings.encoding, "UTF8")
+    // ctx.setSetting(ctx.settings.classpath, Jars.dottyLib)
+    // when classpath is changed in ctx, we need to re-initialize to get the
+    // correct classpath from PathResolver
+    // base.initialize()(ctx)
+    ctx
+  }
+
+  /*
+  val toolbox = new DottyToolbox()(context)
+
+  test("literals") {
+    assert(q"5" eq toolbox.Lit(5))
+  }*/
+
   /*
   test("param\"${name(index)} : $tp\"") {
     val name = Term.Name("name")


### PR DESCRIPTION
I've moved quasiquote test to the outer project before (probably after a drink), it does't make any sense, as the outer project is compiled by scalac instead of modified version of dotty.
