### PR TITLE
Split toolbox to StructToolbox and TypeToolbox

### DIFF
--- a/macros/src/main/scala/gestalt/macros/Annotations.scala
+++ b/macros/src/main/scala/gestalt/macros/Annotations.scala
@@ -5,11 +5,11 @@ import scala.gestalt._
 
 class main extends StaticAnnotation {
   inline def apply(defn: Any): Any = meta {
-    val toolbox.Object(mods, name, parents, self, stats) = defn
+    val q"$mods object $name { ..$stats }" = defn
     val main = q"""
       def stub(args: Any): Any = { ..$stats }
     """
-    toolbox.Object(mods, name, parents, self, List(main))
+    q"$mods object $name { $main }"
   }
 }
 

--- a/macros/src/main/scala/gestalt/macros/Annotations.scala
+++ b/macros/src/main/scala/gestalt/macros/Annotations.scala
@@ -5,11 +5,11 @@ import scala.gestalt._
 
 class main extends StaticAnnotation {
   inline def apply(defn: Any): Any = meta {
-    val q"object $name { ..$stats }" = defn
+    val toolbox.Object(mods, name, parents, self, stats) = defn
     val main = q"""
       def stub(args: Any): Any = { ..$stats }
     """
-    q"object $name { $main }"
+    toolbox.Object(mods, name, parents, self, List(main))
   }
 }
 

--- a/macros/src/main/scala/gestalt/macros/Annotations.scala
+++ b/macros/src/main/scala/gestalt/macros/Annotations.scala
@@ -19,6 +19,7 @@ class replace extends StaticAnnotation {
   }
 }
 
+
 /*
 class data extends StaticAnnotation {
   inline def apply(defn: Any): Any = meta {

--- a/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
+++ b/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
@@ -1,0 +1,17 @@
+import scala.annotation.StaticAnnotation
+import scala.collection.immutable.Seq
+
+import scala.gestalt._
+
+class modsTest extends StaticAnnotation {
+  inline def apply(defn: Any): Any = meta {
+    val q"$mods object $name" = q"private object A"
+    println(mods.toString)
+    assert(mods.is(flags.Private))
+
+    // val q"$mods class $name" = q"case class A(x: Int)"
+    // assert(mods.is(flags.Case))
+
+    defn
+  }
+}

--- a/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
+++ b/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
@@ -6,7 +6,6 @@ import scala.gestalt._
 class modsTest extends StaticAnnotation {
   inline def apply(defn: Any): Any = meta {
     val q"$mods object $name" = q"private object A"
-    println(mods.toString)
     assert(mods.is(flags.Private))
 
     val q"$mods1 class $name2 $mods2 ($params)" = q"case class A private[core](x: Int)"

--- a/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
+++ b/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
@@ -9,8 +9,10 @@ class modsTest extends StaticAnnotation {
     println(mods.toString)
     assert(mods.is(flags.Private))
 
-    // val q"$mods class $name" = q"case class A(x: Int)"
-    // assert(mods.is(flags.Case))
+    val q"$mods1 class $name2 $mods2 ($params)" = q"case class A private[core](x: Int)"
+    assert(mods1.is(flags.Case))
+    assert(mods2.is(flags.Private))
+    assert(mods2.privateWithin == "core")
 
     defn
   }

--- a/macros/src/test/scala/gestalt/macros/QuasiquoteTest.scala
+++ b/macros/src/test/scala/gestalt/macros/QuasiquoteTest.scala
@@ -4,7 +4,7 @@ import dotty.tools._
 import dotc.core.Contexts._
 
 import scala.gestalt._
-import dotty.DottyToolbox
+import dotty.Toolbox
 
 class QuasiquoteTest extends TestSuite {
   val context: Context = {

--- a/macros/src/test/scala/gestalt/macros/QuasiquoteTest.scala
+++ b/macros/src/test/scala/gestalt/macros/QuasiquoteTest.scala
@@ -18,6 +18,10 @@ class QuasiquoteTest extends TestSuite {
     ctx
   }
 
+  test("test modifiers") {
+    @modsTest val x = 5
+  }
+
   /*
   val toolbox = new DottyToolbox()(context)
 

--- a/src/main/scala/gestalt/Quasiquote.scala
+++ b/src/main/scala/gestalt/Quasiquote.scala
@@ -64,13 +64,14 @@ class Quasiquote(val t: Toolbox, val toolboxName: String) {
   import t._
   import Quasiquote._
 
-  def expand(label: String, parts: List[String], unquotes: List[Tree], isPattern: Boolean): Tree = {
+  def expand(label: String, tree: Tree, parts: List[String], unquotes: List[Tree], isPattern: Boolean): Tree = {
     val code = resugar(parts)
     val parser = instantiateParser(parserMap(label))
     val mTree = parser(m.Input.String(code), quasiquoteTermDialect)
     val quote = new Quote(t, toolboxName) {
       val args = unquotes.asInstanceOf[List[this.t.Tree]]    // fix compiler stupidity
       val isTerm = !isPattern
+      val enclosingTree = tree.asInstanceOf[this.t.Tree]
     }
 
     // compiler stupidity

--- a/src/main/scala/gestalt/Toolbox.scala
+++ b/src/main/scala/gestalt/Toolbox.scala
@@ -55,9 +55,8 @@ trait Toolbox {
   type TypeTree <: Tree      // safety by construction -- implementation can have TypeTree = Tree
   type Mods <: Modifiers[Tree]
 
-  // diagnostics
-  // TODO: should take pos as param -- need to introduce Pos as type param
-  def error(message: String): Nothing = throw new Exception(message)
+  // diagnostics - the implementation takes the position from the tree
+  def error(message: String, tree: Tree): Unit
 
   // modifiers
   def emptyMods: Mods

--- a/src/main/scala/gestalt/Toolbox.scala
+++ b/src/main/scala/gestalt/Toolbox.scala
@@ -6,6 +6,195 @@ trait Toolbox { t =>
   // portable trees -- minimum assumptions
   type Tree <: { def tpe: Type } // TODO: structural types performance penalty.
   type TypeTree <: Tree          // safety by construction -- implementation can have TypeTree = Tree
+
+  // diagnostics
+  // TODO: should take pos as param -- need to introduce Pos as type param
+  def error(message: String): Nothing = throw new Exception(message)
+
+  // definition trees
+  def Object(mods: Mods, name: String, parents: Seq[Tree], selfOpt: Option[Tree], stats: Seq[Tree]): Tree
+  def Class(mods: Mods, name: String, tparams: Seq[Tree], ctor: Option[Tree], parents: Seq[Tree], self: Option[Tree], stats: Seq[Tree]): Tree
+  def Anonym(parents: Seq[Tree], self: Option[Tree], stats: Seq[Tree]): Tree
+  def Trait(mods: Mods, name: String, tparams: Seq[Tree], ctor: Option[Tree], parents: Seq[Tree], self: Option[Tree], stats: Seq[Tree]): Tree
+  def TypeDecl(mods: Mods, name: String, tparams: Seq[Tree], tbounds: Option[TypeTree]): Tree
+  def TypeAlias(mods: Mods, name: String, tparams: Seq[Tree], rhs: TypeTree): Tree
+  def DefDef(mods: Mods, name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: Option[TypeTree], rhs: Tree): Tree
+  def DefCl(mods: Mods, name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: TypeTree): Tree
+  def ValDef(mods: Mods, name: String, tpe: Option[TypeTree], rhs: Tree): Tree
+  def ValDef(mods: Mods, lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree
+  def ValDef(mods: Mods, pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree
+  def ValDecl(mods: Mods, name: String, tpe: TypeTree): Tree
+  def ValDecl(mods: Mods, vals: Seq[String], tpe: TypeTree): Tree
+  def VarDef(mods: Mods, name: String, tpe: Option[TypeTree], rhs: Tree): Tree
+  def VarDef(mods: Mods, lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree
+  def VarDef(mods: Mods, pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree
+  def VarDecl(mods: Mods, name: String, tpe: TypeTree): Tree
+  def VarDecl(mods: Mods, vars: Seq[String], tpe: TypeTree): Tree
+  def Param(mods: Mods, name: String, tpe: Option[TypeTree], default: Option[Tree]): Tree
+  def TypeParam(mods: Mods, name: String, tparams: Seq[TypeTree], tbounds: Option[TypeTree], cbounds: Seq[TypeTree]): TypeTree
+  // extends qual.T[A, B](x, y)(z)
+  def InitCall(qual: Option[Tree], name: String, tparams: Seq[TypeTree], argss: Seq[Seq[Tree]]): Tree
+  def PrimaryCtor(mods: Mods, paramss: Seq[Seq[Tree]]): Tree
+  def SecondaryCtor(mods: Mods, paramss: Seq[Seq[Tree]], rhs: Tree): Tree
+  def Self(name: String, tpe: TypeTree): Tree
+  def Self(name: String): Tree
+
+  // type trees
+  def TypeIdent(name: String): TypeTree
+  def TypeSelect(qual: Tree, name: String): TypeTree
+  def TypeSingleton(ref: Tree): TypeTree
+  def TypeApply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree
+  def TypeApplyInfix(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree
+  def TypeFunction(params: Seq[TypeTree], res: TypeTree): TypeTree
+  def TypeTuple(args: Seq[TypeTree]): TypeTree
+  def TypeAnd(lhs: TypeTree, rhs: TypeTree): TypeTree
+  def TypeOr(lhs: TypeTree, rhs: TypeTree): TypeTree
+  def TypeRefine(tpe : Option[TypeTree], stats: Seq[Tree]): TypeTree
+  def TypeBounds(lo: Option[TypeTree], hi: Option[TypeTree]): TypeTree
+  def TypeRepeated(tpe: TypeTree): TypeTree
+  def TypeByName(tpe: TypeTree): TypeTree
+  def TypeAnnotated(tpe: TypeTree, annots: Seq[Tree]): TypeTree
+
+
+  // terms
+  def Lit(value: Any): Tree
+  def Ident(name: String): Tree
+  def Select(qual: Tree, name: String): Tree
+  def This(qual: String): Tree
+  def Super(thisp: String, superp: String): Tree
+  def Interpolate(prefix: String, parts: Seq[String], args: Seq[Tree]): Tree
+  def Apply(fun: Tree, args: Seq[Tree]): Tree
+  def ApplyType(fun: Tree, args: Seq[TypeTree]): Tree
+  // a + (b, c)  =>  Infix(a, +, Tuple(b, c))
+  def Infix(lhs: Tree, op: String, rhs: Tree): Tree
+  def Prefix(op: String, od: Tree): Tree
+  def Postfix(od: Tree, op: String): Tree
+  def Assign(lhs: Tree, rhs: Tree): Tree
+  def Return(expr: Tree): Tree
+  def Throw(expr: Tree): Tree
+  def Ascribe(expr: Tree, tpe: Tree): Tree
+  def Annotated(expr: Tree, annots: Seq[Tree]): Tree
+  def Tuple(args: Seq[Tree]): Tree
+  def Block(stats: Seq[Tree]): Tree
+  def If(cond: Tree, thenp: Tree, elsep: Option[Tree]): Tree
+  def Match(expr: Tree, cases: Seq[Tree]): Tree
+  def Case(pat: Tree, cond: Option[Tree], body: Tree): Tree
+  def Try(expr: Tree, cases: Seq[Tree], finallyp: Option[Tree]): Tree
+  def Try(expr: Tree, handler: Tree, finallyp: Option[Tree]): Tree
+  def Function(params: Seq[Tree], body: Tree): Tree
+  def PartialFunction(cases: Seq[Tree]): Tree
+  def While(expr: Tree, body: Tree): Tree
+  def DoWhile(body: Tree, expr: Tree): Tree
+  def For(enums: Seq[Tree], body: Tree): Tree
+  def GenFrom(pat: Tree, rhs: Tree): Tree
+  def GenAlias(pat: Tree, rhs: Tree): Tree
+  def Guard(cond: Tree): Tree
+  def Yield(expr: Tree): Tree
+  // can be InitCall or AnonymClass
+  def New(tpe: Tree): Tree
+  def Named(name: String, expr: Tree): Tree
+  def Repeated(expr: Tree): Tree
+
+  // patterns
+  def Bind(name: String, expr: Tree): Tree
+  def Alternative(lhs: Tree, rhs: Tree): Tree
+
+  // helpers
+  def ApplySeq(fun: Tree, argss: Seq[Seq[Tree]]): Tree = argss match {
+    case args :: rest => rest.foldLeft(Apply(fun, args)) { (acc, args) => Apply(acc, args) }
+    case _ => Apply(fun, Nil)
+  }
+
+  // importees
+  def Import(items: Seq[Tree]): Tree
+  def ImportItem(ref: Tree, importees: Seq[Tree]): Tree
+  def ImportName(name: String): Tree
+  def ImportRename(from: String, to: String): Tree
+  def ImportHide(name: String): Tree
+
+
+  // modifiers
+  def empty: Mods
+  trait Mods {
+    def isPrivate: Boolean
+    def setPrivate(within: Tree): Unit
+    def getPrivate: String
+
+    def isProtected: Boolean
+    def setProtected(within: Tree): Unit
+    def getProtected: String
+
+    def isVal: Boolean
+    def setVal: Unit
+
+    def isVar: Boolean
+    def setVar: Unit
+
+    def isImplicit: Boolean
+    def setImplicit: Unit
+
+    def isFinal: Boolean
+    def setFinal: Unit
+
+    def isSealed: Boolean
+    def setSealed: Unit
+
+    def isOverride: Boolean
+    def setOverride: Unit
+
+    def isAbstract: Boolean
+    def setAbstract: Unit
+
+    def isLazy: Boolean
+    def setLazy: Unit
+
+    def isInline: Boolean
+    def setInline: Unit
+
+    def isCase: Boolean
+    def setCase: Unit
+
+    def isContravariant: Boolean
+    def setContravariant: Unit
+
+    def isCovariant: Boolean
+    def setCovariant: Unit
+
+    def addAnnot(annot: Tree): Unit
+  }
+}
+
+/** StructToolbox defines extractors available for inspecting definition trees
+ *
+ *  To provide solid experience of macros, we only provide extractors for definition trees, like object, class, trait.
+ *
+ *  TODO:
+ *
+ *  another choice:
+ *    Provide definition tree transformers so that attachments (docs, etc) on the
+ *    current tree is not an issue.
+ */
+trait StructToolbox extends Toolbox {
+  // standard constructors and extractors
+  val Object: ObjectHelper
+  trait ObjectHelper {
+    def unapply(tree: Tree): Option[(Mods, String, Seq[Tree], Option[Tree], Seq[Tree])]
+  }
+
+  val Class: ClassHelper
+  trait ClassHelper {
+    def unapply(tree: Tree): Option[(Mods, String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])]
+  }
+
+  val Trait: TraitHelper
+  trait TraitHelper {
+    def unapply(tree: Tree): Option[(Mods, String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])]
+  }
+}
+
+/** TypeToolbox defines extractors for inspecting expression trees
+ */
+trait TypeToolbox extends Toolbox {
   type Type
 
   // type operations
@@ -18,237 +207,27 @@ trait Toolbox { t =>
   def <:<(tp1: Type, tp2: Type): Boolean
   def typeOf(path: String): Type
 
-  // diagnostics
-  // TODO: should take pos as param -- need to introduce Pos as type param
-  def error(message: String): Nothing = throw new Exception(message)
-
-  // standard constructors and extractors
-  val Object: ObjectHelper
-  trait ObjectHelper {
-    def apply(mods: Seq[Tree], name: String, parents: Seq[Tree], selfOpt: Option[Tree], stats: Seq[Tree]): Tree
-    def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree])]
-  }
-
-  val Class: ClassHelper
-  trait ClassHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], ctor: Option[Tree], parents: Seq[Tree], self: Option[Tree], stats: Seq[Tree]): Tree
-    def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])]
-  }
-
-  val AnonymClass: AnonymClassHelper
-  trait AnonymClassHelper {
-    def apply(parents: Seq[Tree], self: Option[Tree], stats: Seq[Tree]): Tree
-  }
-
-  val Trait: TraitHelper
-  trait TraitHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], ctor: Option[Tree], parents: Seq[Tree], self: Option[Tree], stats: Seq[Tree]): Tree
-    def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])]
-  }
-
-  val TypeDecl: TypeDeclHelper
-  trait TypeDeclHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], tbounds: Option[TypeTree]): Tree
-  }
-
-  val TypeAlias: TypeAliasHelper
-  trait TypeAliasHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], rhs: TypeTree): Tree
-  }
-
-  val DefDef: DefDefHelper
-  trait DefDefHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: Option[TypeTree], rhs: Tree): Tree
-  }
-
-  val DefDecl: DefDeclHelper
-  trait DefDeclHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: TypeTree): Tree
-  }
-
-  val ValDef: ValDefHelper
-  trait ValDefHelper {
-    def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree
-    def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree
-    def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree
-  }
-
-  val ValDecl: ValDeclHelper
-  trait ValDeclHelper {
-    def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree
-    def apply(mods: Seq[Tree], vals: Seq[String], tpe: TypeTree): Tree
-  }
-
-  val VarDef: VarDefHelper
-  trait VarDefHelper {
-    def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree
-    def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree
-    def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree
-  }
-
-  val VarDecl: VarDeclHelper
-  trait VarDeclHelper {
-    def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree
-    def apply(mods: Seq[Tree], vars: Seq[String], tpe: TypeTree): Tree
-  }
-
-  val PrimaryCtor: PrimaryCtorHelper
-  trait PrimaryCtorHelper {
-    def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]]): Tree
-    def unapply(tree: Tree): Option[(Seq[Tree], Seq[Seq[Tree]])]
-  }
-
-  val SecondaryCtor: SecondaryCtorHelper
-  trait SecondaryCtorHelper {
-    def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]], rhs: Tree): Tree
-  }
-
-  // qual.T[A, B](x, y)(z)
-  val InitCall: InitCallHelper
-  trait InitCallHelper {
-    def apply(qual: Option[Tree], name: String, tparams: Seq[TypeTree], argss: Seq[Seq[Tree]]): Tree
-  }
-
-  val Param: ParamHelper
-  trait ParamHelper {
-    def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], default: Option[Tree]): Tree
-    def unapply(tree: Tree): Option[(Seq[Tree], String, Option[TypeTree], Option[Tree])]
-
-    def copy(param: Tree)(
-      mods: Seq[Tree]       = unapply(param).get._1,
-      name: String          = unapply(param).get._2,
-      tpe: Option[TypeTree] = unapply(param).get._3,
-      default: Option[Tree] = unapply(param).get._4
-    ) = apply(mods, name, tpe, default)
-  }
-
-  val TypeParam: TypeParamHelper
-  trait TypeParamHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[TypeTree], tbounds: Option[TypeTree], cbounds: Seq[TypeTree]): TypeTree
-  }
-
-  val Self: SelfHelper
-  trait SelfHelper {
-    def apply(name: String, tpe: TypeTree): Tree
-    def apply(name: String): Tree
-  }
-
-  // types
-  val TypeIdent: TypeIdentHelper
-  trait TypeIdentHelper {
-    def apply(name: String): TypeTree
-  }
-
-  val TypeSelect: TypeSelectHelper
-  trait TypeSelectHelper {
-    def apply(qual: Tree, name: String): TypeTree
-  }
-
-  val TypeSingleton: TypeSingletonHelper
-  trait TypeSingletonHelper {
-    def apply(ref: Tree): TypeTree
-  }
-
-  val TypeApply: TypeApplyHelper
-  trait TypeApplyHelper {
-    def apply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree
-  }
-
-  val TypeApplyInfix: TypeApplyInfixHelper
-  trait TypeApplyInfixHelper {
-    def apply(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree
-  }
-
-  val TypeFunction: TypeFunctionHelper
-  trait TypeFunctionHelper {
-    def apply(params: Seq[TypeTree], res: TypeTree): TypeTree
-  }
-
-  val TypeTuple: TypeTupleHelper
-  trait TypeTupleHelper {
-    def apply(args: Seq[TypeTree]): TypeTree
-  }
-
-  val TypeAnd: TypeAndHelper
-  trait TypeAndHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree
-  }
-
-  val TypeOr: TypeOrHelper
-  trait TypeOrHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree
-  }
-
-  val TypeRefine: TypeRefineHelper
-  trait TypeRefineHelper {
-    def apply(tpe : Option[TypeTree], stats: Seq[Tree]): TypeTree
-  }
-
-  val TypeBounds: TypeBoundsHelper
-  trait TypeBoundsHelper {
-    def apply(lo: Option[TypeTree], hi: Option[TypeTree]): TypeTree
-  }
-
-  val TypeRepeated: TypeRepeatedHelper
-  trait TypeRepeatedHelper {
-    def apply(tpe: TypeTree): TypeTree
-  }
-
-  val TypeByName: TypeByNameHelper
-  trait TypeByNameHelper {
-    def apply(tpe: TypeTree): TypeTree
-  }
-
-  val TypeAnnotated: TypeAnnotatedHelper
-  trait TypeAnnotatedHelper {
-    def apply(tpe: TypeTree, annots: Seq[Tree]): TypeTree
-  }
-
-  // terms
   val Lit: LitHelper
   trait LitHelper {
-    def apply(value: Any): Tree
     def unapply(tree: Tree): Option[Any]
   }
 
   val Ident: IdentHelper
-  trait IdentHelper {
-    def apply(name: String): Tree
-  }
+  trait IdentHelper
 
   val Select: SelectHelper
-  trait SelectHelper {
-    def apply(qual: Tree, name: String): Tree
-  }
+  trait SelectHelper
 
   val This: ThisHelper
-  trait ThisHelper {
-    def apply(qual: String): Tree
-  }
-
-  val Super: SuperHelper
-  trait SuperHelper {
-    def apply(thisp: String, superp: String): Tree
-  }
-
-  val Interpolate: InterpolateHelper
-  trait InterpolateHelper {
-    def apply(prefix: String, parts: Seq[String], args: Seq[Tree]): Tree
-  }
+  trait ThisHelper
 
   val Apply: ApplyHelper
   trait ApplyHelper {
-    def apply(fun: Tree, args: Seq[Tree]): Tree
     def unapply(tree: Tree): Option[(Tree, Seq[Tree])]
   }
 
   // helper
   object ApplySeq {
-    def apply(fun: Tree, argss: Seq[Seq[Tree]]): Tree = argss match {
-      case args :: rest => rest.foldLeft(Apply(fun, args)) { (acc, args) => Apply(acc, args) }
-      case _ => Apply(fun, Nil)
-    }
-
     def unapply(call: Tree):  Option[(Tree, Seq[Seq[Tree]])] = {
       def recur(acc: Seq[Seq[Tree]], term: Tree): (Tree, Seq[Seq[Tree]])  = term match {
         case Apply(fun, args) => recur(args +: acc, fun) // inner-most is in the front
@@ -259,281 +238,4 @@ trait Toolbox { t =>
     }
   }
 
-  val ApplyType: ApplyTypeHelper
-  trait ApplyTypeHelper {
-    def apply(fun: Tree, args: Seq[TypeTree]): Tree
-    def unapply(tree: Tree): Option[(Tree, Seq[TypeTree])]
-  }
-
-  // a + (b, c)  =>  Infix(a, +, Tuple(b, c))
-  val Infix: InfixHelper
-  trait InfixHelper {
-    def apply(lhs: Tree, op: String, rhs: Tree): Tree
-  }
-
-  val Prefix: PrefixHelper
-  trait PrefixHelper {
-    def apply(op: String, od: Tree): Tree
-  }
-
-  val Postfix: PostfixHelper
-  trait PostfixHelper {
-    def apply(od: Tree, op: String): Tree
-  }
-
-  val Assign: AssignHelper
-  trait AssignHelper {
-    def apply(lhs: Tree, rhs: Tree): Tree
-    def unapply(tree: Tree): Option[(Tree, Tree)]
-  }
-
-  val Return: ReturnHelper
-  trait ReturnHelper {
-    def apply(expr: Tree): Tree
-  }
-
-  val Throw: ThrowHelper
-  trait ThrowHelper {
-    def apply(expr: Tree): Tree
-  }
-
-  val Ascribe: AscribeHelper
-  trait AscribeHelper {
-    def apply(expr: Tree, tpe: Tree): Tree
-  }
-
-  val Annotated: AnnotatedHelper
-  trait AnnotatedHelper {
-    def apply(expr: Tree, annots: Seq[Tree]): Tree
-  }
-
-  val Tuple: TupleHelper
-  trait TupleHelper {
-    def apply(args: Seq[Tree]): Tree
-  }
-
-  val Block: BlockHelper
-  trait BlockHelper {
-    def apply(stats: Seq[Tree]): Tree
-  }
-
-  val If: IfHelper
-  trait IfHelper {
-    def apply(cond: Tree, thenp: Tree, elsep: Option[Tree]): Tree
-  }
-
-  val Match: MatchHelper
-  trait MatchHelper {
-    def apply(expr: Tree, cases: Seq[Tree]): Tree
-  }
-
-  val Case: CaseHelper
-  trait CaseHelper {
-    def apply(pat: Tree, cond: Option[Tree], body: Tree): Tree
-  }
-
-  val Try: TryHelper
-  trait TryHelper {
-    def apply(expr: Tree, cases: Seq[Tree], finallyp: Option[Tree]): Tree
-    def apply(expr: Tree, handler: Tree, finallyp: Option[Tree]): Tree
-  }
-
-  val Function: FunctionHelper
-  trait FunctionHelper {
-    def apply(params: Seq[Tree], body: Tree): Tree
-  }
-
-  val PartialFunction: PartialFunctionHelper
-  trait PartialFunctionHelper {
-    def apply(cases: Seq[Tree]): Tree
-  }
-
-  val While: WhileHelper
-  trait WhileHelper {
-    def apply(expr: Tree, body: Tree): Tree
-  }
-
-  val DoWhile: DoWhileHelper
-  trait DoWhileHelper {
-    def apply(body: Tree, expr: Tree): Tree
-  }
-
-  val For: ForHelper
-  trait ForHelper {
-    def apply(enums: Seq[Tree], body: Tree): Tree
-  }
-
-  val GenFrom: GenFromHelper
-  trait GenFromHelper {
-    def apply(pat: Tree, rhs: Tree): Tree
-  }
-
-  val GenAlias: GenAliasHelper
-  trait GenAliasHelper {
-    def apply(pat: Tree, rhs: Tree): Tree
-  }
-
-  val Guard: GuardHelper
-  trait GuardHelper {
-    def apply(cond: Tree): Tree
-  }
-
-  val Yield: YieldHelper
-  trait YieldHelper {
-    def apply(expr: Tree): Tree
-  }
-
-  // can be InitCall or AnonymClass
-  val New: NewHelper
-  trait NewHelper {
-    def apply(tpe: Tree): Tree
-  }
-
-  val Named: NamedHelper
-  trait NamedHelper {
-    def apply(name: String, expr: Tree): Tree
-  }
-
-  val Repeated: RepeatedHelper
-  trait RepeatedHelper {
-    def apply(expr: Tree): Tree
-  }
-
-  // patterns
-  val Bind: BindHelper
-  trait BindHelper {
-    def apply(name: String, expr: Tree): Tree
-  }
-
-  val Alternative: AlternativeHelper
-  trait AlternativeHelper {
-    def apply(lhs: Tree, rhs: Tree): Tree
-  }
-
-  // importees
-  val Import: ImportHelper
-  trait ImportHelper {
-    def apply(items: Seq[Tree]): Tree
-  }
-
-  val ImportItem: ImportItemHelper
-  trait ImportItemHelper {
-    def apply(ref: Tree, importees: Seq[Tree]): Tree
-  }
-
-  val ImportName: ImportNameHelper
-  trait ImportNameHelper {
-    def apply(name: String): Tree
-  }
-
-  val ImportRename: ImportRenameHelper
-  trait ImportRenameHelper {
-    def apply(from: String, to: String): Tree
-  }
-
-  val ImportHide: ImportHideHelper
-  trait ImportHideHelper {
-    def apply(name: String): Tree
-  }
-
-  // modifiers
-  val Mod: ModHelper
-  trait ModHelper {
-    val Private: PrivateHelper
-    trait PrivateHelper {
-      def apply(within: String): Tree
-      def unapply(tree: Tree): Option[String]
-    }
-
-    val Protected: ProtectedHelper
-    trait ProtectedHelper {
-      def apply(within: String): Tree
-      def unapply(tree: Tree): Option[String]
-    }
-
-    val Val: ValHelper
-    trait ValHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Var: VarHelper
-    trait VarHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Implicit: ImplicitHelper
-    trait ImplicitHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Final: FinalHelper
-    trait FinalHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Sealed: SealedHelper
-    trait SealedHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Override: OverrideHelper
-    trait OverrideHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Abstract: AbstractHelper
-    trait AbstractHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Lazy: LazyHelper
-    trait LazyHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Inline: InlineHelper
-    trait InlineHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Type: TypeHelper
-    trait TypeHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Case: CaseHelper
-    trait CaseHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Contravariant: ContravariantHelper
-    trait ContravariantHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Covariant: CovariantHelper
-    trait CovariantHelper {
-      def apply(): Tree
-      def unapply(tree: Tree): Boolean
-    }
-
-    val Annot: AnnotHelper
-    trait AnnotHelper {
-      def apply(body: Tree): Tree
-      def unapply(tree: Tree): Option[Tree]
-    }
-  }
 }
-

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -79,6 +79,10 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
     def withPosition = tree.withPos(enclosingPosition)
   }
 
+  // diagnostics - the implementation takes the position from the tree
+  def error(message: String, tree: Tree): Unit = {
+    ctx.error(message, tree.pos)
+  }
   //----------------------------------------
 
   // modifiers

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -1,6 +1,6 @@
 package scala.gestalt.dotty
 
-import scala.gestalt.Toolbox
+import scala.gestalt.{Toolbox => Tbox, StructToolbox => STbox, TypeToolbox => TTbox, Modifiers => Mods}
 import scala.collection.immutable.Seq
 
 import dotty.tools.dotc._
@@ -17,14 +17,61 @@ import Positions.Position
 
 import scala.collection.mutable.ListBuffer
 
-class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends Toolbox {
+class Modifiers(var mods: d.Modifiers) extends Mods[d.Tree] {
+  def isPrivate: Boolean = mods is Flags.Private
+  def getPrivate: String = if (mods is Flags.Local) "this" else mods.privateWithin.toString
+  def setPrivate(within: String): Unit = {
+    if (within == "this") mods = mods | Flags.Local
+    else mods = mods.withPrivateWithin(within.toTypeName)
+  }
+
+  def isProtected: Boolean = mods is Flags.Protected
+  def getProtected: String = mods.privateWithin.toString
+  def setProtected(within: String): Unit = mods = mods.withPrivateWithin(within.toTypeName)
+
+  def isVal: Boolean = mods.mods.exists(_.isInstanceOf[d.Mod.Val])
+  def setVal: Unit = mods = mods.withAddedMod(d.Mod.Val())
+
+  def isVar: Boolean = mods is Flags.Mutable
+  def setVar: Unit = mods = mods | Flags.Mutable
+
+  def isImplicit: Boolean = mods is Flags.Implicit
+  def setImplicit: Unit = mods = mods | Flags.Implicit
+
+  def isFinal: Boolean = mods is Flags.Final
+  def setFinal: Unit = mods = mods | Flags.Final
+
+  def isSealed: Boolean = mods is Flags.Sealed
+  def setSealed: Unit = mods = mods | Flags.Sealed
+
+  def isOverride: Boolean = mods is Flags.Override
+  def setOverride: Unit = mods = mods | Flags.Override
+
+  def isAbstract: Boolean = mods is Flags.Abstract
+  def setAbstract: Unit = mods = mods | Flags.Abstract
+
+  def isLazy: Boolean = mods is Flags.Lazy
+  def setLazy: Unit = mods = mods | Flags.Lazy
+
+  def isInline: Boolean = mods is Flags.Inline
+  def setInline: Unit = mods = mods | Flags.Inline
+
+  def isCase: Boolean = mods is Flags.Case
+  def setCase: Unit = mods = mods | Flags.Case
+
+  def isContravariant: Boolean = mods is Flags.Contravariant
+  def setContravariant: Unit = mods = mods | Flags.Contravariant
+
+  def isCovariant: Boolean = mods is Flags.Covariant
+  def setCovariant: Unit = mods = mods | Flags.Covariant
+
+  def addAnnot(annot: d.Tree): Unit = mods = mods.withAddedAnnotation(annot)
+}
+
+class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
   type Tree = d.Tree
   type TypeTree = d.Tree
-  type Type = Types.Type
-
-  def =:=(tp1: Type, tp2: Type): Boolean = ???
-  def <:<(tp1: Type, tp2: Type): Boolean = ???
-  def typeOf(path: String): Type = ???
+  type Mods = Modifiers
 
   def getOrEmpty(treeOpt: Option[Tree]): Tree = treeOpt.getOrElse(d.EmptyTree)
 
@@ -32,170 +79,340 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
     def withPosition = tree.withPos(enclosingPosition)
   }
 
-  private implicit def fromMods(mods: Seq[Tree]): d.Modifiers = {
-    def addMod(modifiers: d.Modifiers, mod: d.Mod): d.Modifiers =
-      modifiers.withAddedMod(mod) | mod.flags
+  //----------------------------------------
 
-    mods.foldLeft(d.Modifiers()) { (modifiers, mod) =>
-      mod match {
-        case Mod.Annot(body) =>
-          modifiers.withAddedAnnotation(body)
-        case Mod.Private(within) =>
-          val modifiers2 = within match {
-            case "this" => modifiers | Flags.Local
-            case  _     => modifiers.withPrivateWithin(within.toTypeName)
-          }
-          addMod(modifiers2, d.Mod.Private())
-        case Mod.Protected(within) =>
-          val modifiers2 = within match {
-            case "this" => modifiers | Flags.Local
-            case  _     => modifiers.withPrivateWithin(within.toTypeName)
-          }
-          addMod(modifiers2, d.Mod.Protected())
-        case Mod.Implicit() =>
-          addMod(modifiers, d.Mod.Implicit())
-        case Mod.Final() =>
-          addMod(modifiers, d.Mod.Final())
-        case Mod.Sealed() =>
-          addMod(modifiers, d.Mod.Sealed())
-        case Mod.Override() =>
-          addMod(modifiers, d.Mod.Override())
-        case Mod.Case() =>
-          modifiers | Flags.Case
-        case Mod.Abstract() =>
-          addMod(modifiers, d.Mod.Abstract())
-        case Mod.Covariant() =>
-          modifiers | Flags.Covariant
-        case Mod.Contravariant() =>
-          modifiers | Flags.Contravariant
-        case Mod.Lazy() =>
-          addMod(modifiers, d.Mod.Lazy())
-        case Mod.Val() =>
-          addMod(modifiers, d.Mod.Val())
-        case Mod.Var() =>
-          addMod(modifiers, d.Mod.Var())
-        case Mod.Inline() =>
-          addMod(modifiers, d.Mod.Inline())
+  // modifiers
+  def emptyMods: Mods = new Modifiers(d.EmptyModifiers)
+
+  def Object(mods: Mods, name: String, parents: Seq[Tree], selfOpt: Option[Tree], stats: Seq[Tree]): Tree = {
+    val constr = d.DefDef(nme.CONSTRUCTOR, Nil, Nil, d.TypeTree(), d.EmptyTree)
+    val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
+    val templ = d.Template(constr, parents.toList, self, stats)
+    d.ModuleDef(name.toTermName, templ).withMods(mods.mods).withPosition
+  }
+
+  def Class(mods: Mods, name: String, tparams: Seq[Tree], ctor: Option[Tree], parents: Seq[Tree], selfOpt: Option[Tree], stats: Seq[Tree]): Tree = {
+    val constr =
+      if (ctor.isEmpty) d.DefDef(nme.CONSTRUCTOR, Nil, Nil, d.TypeTree(), d.EmptyTree)
+      else {
+        val PrimaryCtorTree(mods, paramss) = ctor.get
+        val tparamsCast = tparams.toList.asInstanceOf[List[d.TypeDef]]
+        val paramssCast = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
+        d.DefDef(nme.CONSTRUCTOR, tparamsCast, paramssCast, d.TypeTree(), d.EmptyTree).withMods(mods.mods)
       }
+
+    val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
+    val templ = d.Template(constr, parents.toList, self, stats)
+    d.TypeDef(name.toTypeName, templ).withMods(mods.mods).withPosition
+  }
+
+  def AnonymClass(parents: Seq[Tree], selfOpt: Option[Tree], stats: Seq[Tree]): Tree = {
+    val init = d.DefDef(nme.CONSTRUCTOR, List(), List(), d.TypeTree(), d.EmptyTree)
+    val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
+    d.Template(init, parents.toList, self, stats).withPosition
+  }
+
+  def Trait(mods: Mods, name: String, tparams: Seq[Tree], ctor: Option[Tree], parents: Seq[Tree], self: Option[Tree], stats: Seq[Tree]): Tree =
+    Class(mods, name, tparams, ctor, parents, self, stats).asInstanceOf[d.TypeDef].withFlags(Flags.Trait).withPosition
+
+  def TypeDecl(mods: Mods, name: String, tparams: Seq[Tree], tboundsOpt: Option[TypeTree]): Tree = {
+    val tbounds = tboundsOpt.getOrElse(d.TypeBoundsTree(d.EmptyTree, d.EmptyTree))
+    val body =
+      if (tparams.size == 0) tbounds
+      else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], tbounds)
+    d.TypeDef(name.toTypeName, body).withMods(mods.mods).withPosition
+  }
+
+  def TypeAlias(mods: Mods, name: String, tparams: Seq[Tree], rhs: TypeTree): Tree = {
+    val body =
+      if (tparams.size == 0) rhs
+      else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], rhs)
+    d.TypeDef(name.toTypeName, body).withMods(mods.mods).withPosition
+  }
+
+  def DefDef(mods: Mods, name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: Option[TypeTree], rhs: Tree): Tree = {
+    val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
+    val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
+    d.DefDef(name.toTermName, types, params, tpe.getOrElse(d.TypeTree()), rhs).withMods(mods.mods).withPosition
+  }
+
+  def DefDecl(mods: Mods, name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: TypeTree): Tree = {
+    val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
+    val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
+    d.DefDef(name.toTermName, types, params, tpe, d.EmptyTree).withMods(mods.mods).withPosition
+  }
+
+  def ValDef(mods: Mods, name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
+    d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(mods.mods).withPosition
+
+  def ValDef(mods: Mods, lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
+    d.PatDef(mods.mods, List(lhs), tpe.getOrElse(d.TypeTree()), rhs).withPosition
+
+  def ValDef(mods: Mods, pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
+    d.PatDef(mods.mods, pats.toList, tpe.getOrElse(d.TypeTree()), rhs).withPosition
+
+  def ValDecl(mods: Mods, name: String, tpe: TypeTree): Tree =
+    d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(mods.mods).withPosition
+
+  def ValDecl(mods: Mods, vals: Seq[String], tpe: TypeTree): Tree =
+    d.PatDef(mods.mods, vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree).withPosition
+
+  def VarDef(mods: Mods, name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
+    d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(mods.mods | Flags.Mutable).withPosition
+
+  def VarDef(mods: Mods, lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
+    d.PatDef(mods.mods | Flags.Mutable, List(lhs), tpe.getOrElse(d.TypeTree()), rhs).withPosition
+
+  def VarDef(mods: Mods, pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
+    d.PatDef(mods.mods | Flags.Mutable, pats.toList, tpe.getOrElse(d.TypeTree()), rhs).withPosition
+
+  def VarDecl(mods: Mods, name: String, tpe: TypeTree): Tree =
+    d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(mods.mods | Flags.Mutable).withPosition
+
+  def VarDecl(mods: Mods, vals: Seq[String], tpe: TypeTree): Tree =
+    d.PatDef(mods.mods | Flags.Mutable, vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree).withPosition
+
+  // Dummy trees to retrofit Dotty AST
+  protected case class PrimaryCtorTree(mods: Mods, paramss: Seq[Seq[Tree]]) extends d.Tree
+  def PrimaryCtor(mods: Mods, paramss: Seq[Seq[Tree]]): Tree = PrimaryCtorTree(mods, paramss).withPosition
+
+  def SecondaryCtor(mods: Mods, paramss: Seq[Seq[Tree]], rhs: Tree): Tree =
+    DefDef(mods, nme.CONSTRUCTOR.toString, Nil, paramss, Some(d.TypeTree()), rhs).withPosition
+
+  // qual.T[A, B](x, y)(z)
+  def InitCall(qual: Option[Tree], name: String, tparams: Seq[TypeTree], argss: Seq[Seq[Tree]]): Tree = {
+    val select = if (qual.isEmpty) d.Ident(name.toTermName) else d.Select(qual.get, name.toTypeName)
+    val fun = if (tparams.size == 0) select else TypeApply(select, tparams.toList)
+    ApplySeq(fun, argss).withPosition
+  }
+
+  def Param(mods: Mods, name: String, tpe: Option[TypeTree], default: Option[Tree]): Tree = {
+    d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), getOrEmpty(default)).withMods(mods.mods).withFlags(Flags.TermParam).withPosition
+  }
+
+  def TypeParam(mods: Mods, name: String, tparams: Seq[TypeTree], tboundsOpt: Option[TypeTree], cbounds: Seq[TypeTree]): TypeTree = {
+    val tbounds = tboundsOpt.getOrElse(d.TypeBoundsTree(d.EmptyTree, d.EmptyTree)).asInstanceOf[d.TypeBoundsTree]
+    val inner =
+      if (cbounds.size == 0) tbounds
+      else d.ContextBounds(tbounds, cbounds.toList.map(d.AppliedTypeTree(_, d.Ident(name.toTypeName))))
+
+    val body =
+      if (tparams.size == 0) inner
+      else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], inner)
+
+    d.TypeDef(name.toTypeName, body).withMods(mods.mods).withPosition
+  }
+
+  def Self(name: String, tpe: TypeTree): Tree =
+    d.ValDef(name.toTermName, tpe, d.EmptyTree).withPosition
+
+  def Self(name: String): Tree =
+    d.ValDef(name.toTermName, d.TypeTree(), d.EmptyTree).withPosition
+
+  // types
+  def TypeIdent(name: String): TypeTree = d.Ident(name.toTypeName).withPosition
+
+  def TypeSelect(qual: Tree, name: String): TypeTree = d.Select(qual, name.toTypeName).withPosition
+
+  def TypeSingleton(ref: Tree): TypeTree = d.SingletonTypeTree(ref).withPosition
+
+  def TypeApply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree = d.AppliedTypeTree(tpe, args.toList).withPosition
+
+  def TypeApplyInfix(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree = d.InfixOp(lhs, d.Ident(op.toTypeName), rhs).withPosition
+
+  def TypeFunction(params: Seq[TypeTree], res: TypeTree): TypeTree = d.Function(params.toList, res).withPosition
+
+  def TypeTuple(args: Seq[TypeTree]): TypeTree = d.Tuple(args.toList).withPosition
+
+  def TypeAnd(lhs: TypeTree, rhs: TypeTree): TypeTree = d.AndTypeTree(lhs, rhs).withPosition
+
+  def TypeOr(lhs: TypeTree, rhs: TypeTree): TypeTree = d.OrTypeTree(lhs, rhs).withPosition
+
+  def TypeRefine(tpe: Option[TypeTree], stats: Seq[Tree]): TypeTree =
+    d.RefinedTypeTree(tpe.getOrElse(d.EmptyTree), stats.toList).withPosition
+
+  def TypeBounds(lo: Option[TypeTree], hi: Option[TypeTree]): TypeTree = {
+    require(lo.nonEmpty || hi.nonEmpty)
+    d.TypeBoundsTree(lo.getOrElse(d.EmptyTree), hi.getOrElse(d.EmptyTree)).withPosition
+  }
+
+  def TypeRepeated(tpe: TypeTree): TypeTree = d.PostfixOp(tpe, d.Ident(nme.raw.STAR)).withPosition
+
+  def TypeByName(tpe: TypeTree): TypeTree = d.ByNameTypeTree(tpe).withPosition
+
+  def TypeAnnotated(tpe: TypeTree, annots: Seq[Tree]): TypeTree = {
+    require(annots.size > 0)
+    annots.tail.foldRight(d.Annotated(tpe, annots.head).withPosition) { (ann, acc) =>
+      d.Annotated(acc, ann).withPosition
     }
   }
 
-  private def toMods(modifiers: d.Modifiers): List[Tree] = {
-    val lb = new ListBuffer[Tree]
+  // terms
+  def Lit(value: Any): Tree = d.Literal(Constant(value)).withPosition
 
-    if (modifiers.hasAnnotations) {
-      lb ++= modifiers.annotations.map(Mod.Annot(_))
-    }
+  def Ident(name: String): Tree = d.Ident(name.toTermName).withPosition
 
-    if (modifiers.is(Flags.Case))
-      lb += Mod.Case()
+  def Select(qual: Tree, name: String): Tree = d.Select(qual, name.toTermName).withPosition
 
-    import d.{Mod => mod}
-    lb ++= modifiers.mods.map { modScala =>
-      modScala match {
-        case _: mod.Override =>
-          Mod.Override()
-        case _: mod.Abstract =>
-          Mod.Abstract()
-        case _: mod.Final =>
-          Mod.Final()
-        case _: mod.Implicit =>
-          Mod.Implicit()
-        case _: mod.Inline =>
-          Mod.Inline()
-        case _: mod.Lazy =>
-          Mod.Lazy()
-        case _: mod.Private =>
-          if (modifiers.hasPrivateWithin)
-            Mod.Private(modifiers.privateWithin.toString)
-          else if (modifiers is Flags.Local)
-            Mod.Private("this")
-          else
-            Mod.Private("")
-        case _: mod.Protected =>
-          if (modifiers.hasPrivateWithin)
-            Mod.Protected(modifiers.privateWithin.toString)
-          else if (modifiers is Flags.Local)
-            Mod.Protected("this")
-          else
-            Mod.Protected("")
-        case _: mod.Sealed =>
-          Mod.Sealed()
-        case _: mod.Type =>
-          Mod.Type()
-        case _: mod.Val =>
-          Mod.Val()
-        case _: mod.Var =>
-          Mod.Var()
-      }
-    }
+  def This(qual: String): Tree = d.This(d.Ident(qual.toTypeName)).withPosition
 
-    if (modifiers.is(Flags.Covariant)) lb += Mod.Covariant()
-    if (modifiers.is(Flags.Contravariant)) lb += Mod.Contravariant()
+  def Super(thisp: String, superp: String): Tree =
+    d.Super(d.Ident(thisp.toTypeName), d.Ident(superp.toTypeName)).withPosition
 
-    lb.toList
+  def Interpolate(prefix: String, parts: Seq[String], args: Seq[Tree]): Tree = {
+    val thickets =
+      for {(arg, part) <- args.zip(parts.take(args.size))}
+        yield {
+          val expr = arg match {
+            case tree: d.Ident => tree
+            case tree => d.Block(Nil, tree)
+          }
+          d.Thicket(Lit(part), expr)
+        }
+    val segments =
+      if (parts.size > args.size)
+        thickets :+ Lit(parts.last)
+      else thickets
+
+    d.InterpolatedString(prefix.toTermName, segments.toList).withPosition
   }
+
+  def Apply(fun: Tree, args: Seq[Tree]): Tree = d.Apply(fun, args.toList).withPosition
+
+  def ApplyType(fun: Tree, args: Seq[TypeTree]): Tree = d.TypeApply(fun, args.toList).withPosition
+
+  // a + (b, c)  =>  Infix(a, +, Tuple(b, c))
+  def Infix(lhs: Tree, op: String, rhs: Tree): Tree =
+    d.Apply(d.Select(lhs, op.toTermName), List(rhs)).withPosition
+
+  def Prefix(op: String, od: Tree): Tree = d.PrefixOp(d.Ident(op.toTermName), od).withPosition
+
+  def Postfix(od: Tree, op: String): Tree = d.PostfixOp(od, d.Ident(op.toTermName)).withPosition
+
+  def Assign(lhs: Tree, rhs: Tree): Tree = d.Assign(lhs, rhs).withPosition
+
+  def Return(expr: Tree): Tree = d.Return(expr, d.EmptyTree).withPosition
+
+  def Throw(expr: Tree): Tree = d.Throw(expr).withPosition
+
+  def Ascribe(expr: Tree, tpe: Tree): Tree = d.Typed(expr, tpe).withPosition
+
+  def Annotated(expr: Tree, annots: Seq[Tree]): Tree = {
+    require(annots.size > 0)
+    annots.tail.foldRight(d.Annotated(expr, annots.head).withPosition) { (ann, acc) =>
+      d.Annotated(acc, ann).withPosition
+    }
+  }
+
+  def Tuple(args: Seq[Tree]): Tree = d.Tuple(args.toList).withPosition
+
+  def Block(stats: Seq[Tree]): Tree = {
+    if (stats.size == 0)
+      d.Block(stats.toList, d.EmptyTree).withPosition
+    else
+      d.Block(stats.init.toList, stats.last).withPosition
+  }
+
+  def If(cond: Tree, thenp: Tree, elsep: Option[Tree]): Tree =
+    d.If(cond, thenp, elsep.getOrElse(d.EmptyTree)).withPosition
+
+  def Match(expr: Tree, cases: Seq[Tree]): Tree =
+    d.Match(expr, cases.toList.asInstanceOf[List[d.CaseDef]]).withPosition
+
+  def Case(pat: Tree, cond: Option[Tree], body: Tree): Tree =
+    d.CaseDef(pat, cond.getOrElse(d.EmptyTree), body).withPosition
+
+  def Try(expr: Tree, cases: Seq[Tree], finallyp: Option[Tree]): Tree =
+    d.Try(expr, cases.toList.asInstanceOf[List[d.CaseDef]], finallyp.getOrElse(d.EmptyTree)).withPosition
+
+  def Try(expr: Tree, handler: Tree, finallyp: Option[Tree]): Tree =
+    d.ParsedTry(expr, handler, finallyp.getOrElse(d.EmptyTree)).withPosition
+
+  def Function(params: Seq[Tree], body: Tree): Tree =
+    d.Function(params.toList, body).withPosition
+
+  def PartialFunction(cases: Seq[Tree]): Tree =
+    d.Match(d.Thicket(Nil), cases.toList.asInstanceOf[List[d.CaseDef]]).withPosition
+
+  def While(expr: Tree, body: Tree): Tree = d.WhileDo(expr, body).withPosition
+
+  def DoWhile(body: Tree, expr: Tree): Tree = d.DoWhile(body, expr).withPosition
+
+  def For(enums: Seq[Tree], body: Tree): Tree = ???
+
+  def GenFrom(pat: Tree, rhs: Tree): Tree = ???
+
+  def GenAlias(pat: Tree, rhs: Tree): Tree = ???
+
+  def Guard(cond: Tree): Tree = ???
+
+  def Yield(expr: Tree): Tree = ???
+
+  // can be InitCall or AnonymClass
+  def New(tpe: Tree): Tree = d.New(tpe).withPosition
+
+  def Named(name: String, expr: Tree): Tree =
+    d.NamedArg(name.toTermName, expr).withPosition
+
+  def Repeated(expr: Tree): Tree =
+    d.Typed(expr, d.Ident(tpnme.WILDCARD_STAR)).withPosition
+
+  // patterns
+  def Bind(name: String, expr: Tree): Tree =
+    d.Bind(name.toTermName, expr).withPosition
+
+  def Alternative(lhs: Tree, rhs: Tree): Tree =
+    d.Alternative(List(lhs, rhs)).withPosition
+
+  // importees
+  def Import(items: Seq[Tree]): Tree =
+    if (items.size == 1)
+      items(0).withPosition
+    else
+      d.Thicket(items.toList).withPosition
+
+  def ImportItem(ref: Tree, importees: Seq[Tree]): Tree =
+    d.Import(ref, importees.toList).withPosition
+
+  def ImportName(name: String): Tree = d.Ident(name.toTermName).withPosition
+
+  def ImportRename(from: String, to: String): Tree =
+    d.Thicket(d.Ident(from.toTermName), d.Ident(to.toTermName)).withPosition
+
+  def ImportHide(name: String): Tree =
+    d.Thicket(d.Ident(name.toTermName), d.Ident(nme.WILDCARD)).withPosition
+
+}
+
+class StructToolbox(enclosingPosition: Position)(implicit ctx: Context) extends Toolbox(enclosingPosition)(ctx) with STbox {
 
   object Object extends ObjectHelper {
-    def apply(mods: Seq[Tree], name: String, parents: Seq[Tree], selfOpt: Option[Tree], stats: Seq[Tree]): Tree = {
-      val constr = d.DefDef(nme.CONSTRUCTOR, Nil, Nil, d.TypeTree(), d.EmptyTree)
-      val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
-      val templ = d.Template(constr, parents.toList, self, stats)
-      d.ModuleDef(name.toTermName, templ).withMods(fromMods(mods)).withPosition
-    }
-
-    def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree])] = tree match {
+    def unapply(tree: Tree): Option[(Mods, String, Seq[Tree], Option[Tree], Seq[Tree])] = tree match {
       case obj @ d.ModuleDef(name, templ @ c.Template(constr, parents, self: d.ValDef, body)) =>
         val selfOpt = if (self.name == nme.WILDCARD || self.isEmpty) None else Some(Self(self.name.toString, self.tpt))
-        Some((toMods(obj.mods), name.toString, parents, selfOpt, templ.body))
+        Some((new Modifiers(obj.mods), name.toString, parents, selfOpt, templ.body))
       case _ => None
     }
   }
 
   object Class extends ClassHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], ctor: Option[Tree], parents: Seq[Tree], selfOpt: Option[Tree], stats: Seq[Tree]): Tree = {
-      val constr =
-        if (ctor.isEmpty) d.DefDef(nme.CONSTRUCTOR, Nil, Nil, d.TypeTree(), d.EmptyTree)
-        else {
-          val PrimaryCtor(mods, paramss) = ctor.get
-          val tparamsCast = tparams.toList.asInstanceOf[List[d.TypeDef]]
-          val paramssCast = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
-          d.DefDef(nme.CONSTRUCTOR, tparamsCast, paramssCast, d.TypeTree(), d.EmptyTree).withMods(fromMods(mods))
-        }
-
-      val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
-      val templ = d.Template(constr, parents.toList, self, stats)
-      d.TypeDef(name.toTypeName, templ).withMods(fromMods(mods)).withPosition
-    }
-
-    def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])] = tree match {
+    def unapply(tree: Tree): Option[(Mods, String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])] = tree match {
       case cdef @ c.TypeDef(name, templ @ c.Template(constr, parents, self, body)) =>
         var tparams: List[Tree] = Nil
         val ctor = constr match {
           case c.DefDef(nme.CONSTRUCTOR, Nil, Nil, c.TypeTree(), d.EmptyTree) => None
           case pctor @ c.DefDef(nme.CONSTRUCTOR, tps, paramss, c.TypeTree(), d.EmptyTree) =>
             tparams = tps
-            Some(PrimaryCtor(toMods(pctor.mods), paramss))
+            Some(PrimaryCtor(new Modifiers(pctor.mods), paramss))
         }
         val selfOpt = if (self.name == nme.WILDCARD && self.tpt == d.TypeTree()) None else Some(Self(self.name.toString, self.tpt))
-        Some((toMods(cdef.mods), name.toString, tparams, ctor, tparams, selfOpt, templ.body))  // TODO: parents
+        Some((new Modifiers(cdef.mods), name.toString, tparams, ctor, tparams, selfOpt, templ.body))  // TODO: parents
       case _ => None
     }
   }
 
-  object AnonymClass extends AnonymClassHelper {
-    def apply(parents: Seq[Tree], selfOpt: Option[Tree], stats: Seq[Tree]): Tree = {
-      val init = d.DefDef(nme.CONSTRUCTOR, List(), List(), d.TypeTree(), d.EmptyTree)
-      val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
-      d.Template(init, parents.toList, self, stats).withPosition
-    }
-  }
-
   object Trait extends TraitHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], ctor: Option[Tree], parents: Seq[Tree], self: Option[Tree], stats: Seq[Tree]): Tree =
-      Class(mods, name, tparams, ctor, parents, self, stats).asInstanceOf[d.TypeDef].withFlags(Flags.Trait).withPosition
-
-    def unapply(tree: Tree): Option[(Seq[Tree], String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])] =
+    def unapply(tree: Tree): Option[(Mods, String, Seq[Tree], Option[Tree], Seq[Tree], Option[Tree], Seq[Tree])] =
       if (!tree.isInstanceOf[d.TypeDef]) return None
       else {
         val typedef = tree.asInstanceOf[d.TypeDef]
@@ -205,589 +422,60 @@ class DottyToolbox(enclosingPosition: Position)(implicit ctx: Context) extends T
       }
   }
 
-  object TypeDecl extends TypeDeclHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], tboundsOpt: Option[TypeTree]): Tree = {
-      val tbounds = tboundsOpt.getOrElse(d.TypeBoundsTree(d.EmptyTree, d.EmptyTree))
-      val body =
-        if (tparams.size == 0) tbounds
-        else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], tbounds)
-      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPosition
-    }
-  }
-
-  object TypeAlias extends TypeAliasHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], rhs: TypeTree): Tree = {
-      val body =
-        if (tparams.size == 0) rhs
-        else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], rhs)
-      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPosition
-    }
-  }
-
-  object DefDef extends DefDefHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: Option[TypeTree], rhs: Tree): Tree = {
-      val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
-      val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
-      d.DefDef(name.toTermName, types, params, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)).withPosition
-    }
-  }
-
-  object DefDecl extends DefDeclHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[Tree], paramss: Seq[Seq[Tree]], tpe: TypeTree): Tree = {
-      val types = tparams.toList.asInstanceOf[List[d.TypeDef]]
-      val params = paramss.map(_.toList).toList.asInstanceOf[List[List[d.ValDef]]]
-      d.DefDef(name.toTermName, types, params, tpe, d.EmptyTree).withMods(fromMods(mods)).withPosition
-    }
-  }
-
-  object ValDef extends ValDefHelper {
-    def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods)).withPosition
-
-    def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods), List(lhs), tpe.getOrElse(d.TypeTree()), rhs).withPosition
-
-    def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods), pats.toList, tpe.getOrElse(d.TypeTree()), rhs).withPosition
-  }
-
-  object ValDecl extends ValDeclHelper {
-    def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods)).withPosition
-
-    def apply(mods: Seq[Tree], vals: Seq[String], tpe: TypeTree): Tree =
-      d.PatDef(fromMods(mods), vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree).withPosition
-  }
-
-  object VarDef extends VarDefHelper {
-    def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), rhs).withMods(fromMods(mods) | Flags.Mutable).withPosition
-
-    def apply(mods: Seq[Tree], lhs: Tree, tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, List(lhs), tpe.getOrElse(d.TypeTree()), rhs).withPosition
-
-    def apply(mods: Seq[Tree], pats: Seq[Tree], tpe: Option[TypeTree], rhs: Tree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, pats.toList, tpe.getOrElse(d.TypeTree()), rhs).withPosition
-  }
-
-  object VarDecl extends VarDeclHelper {
-    def apply(mods: Seq[Tree], name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withMods(fromMods(mods) | Flags.Mutable).withPosition
-
-    def apply(mods: Seq[Tree], vals: Seq[String], tpe: TypeTree): Tree =
-      d.PatDef(fromMods(mods) | Flags.Mutable, vals.map(n => d.Ident(n.toTermName)).toList, tpe, d.EmptyTree).withPosition
-  }
-
   object PrimaryCtor extends PrimaryCtorHelper {
-    // Dummy trees to retrofit Dotty AST
-    private case class PrimaryCtorTree(mods: Seq[Tree], paramss: Seq[Seq[Tree]]) extends d.Tree
-
-    def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]]): Tree = PrimaryCtorTree(mods, paramss).withPosition
-
-    def unapply(tree: Tree): Option[(Seq[Tree], Seq[Seq[Tree]])] = tree match {
+    def unapply(tree: Tree): Option[(Mods, Seq[Seq[Tree]])] = tree match {
       case PrimaryCtorTree(mods, paramss) => Some((mods, paramss))
       case _                              => None
     }
   }
 
-  object SecondaryCtor extends SecondaryCtorHelper {
-    def apply(mods: Seq[Tree], paramss: Seq[Seq[Tree]], rhs: Tree): Tree =
-      DefDef(mods, nme.CONSTRUCTOR.toString, Nil, paramss, Some(d.TypeTree()), rhs).withPosition
-  }
-
-  // qual.T[A, B](x, y)(z)
-  object InitCall extends InitCallHelper {
-    def apply(qual: Option[Tree], name: String, tparams: Seq[TypeTree], argss: Seq[Seq[Tree]]): Tree = {
-      val select = if (qual.isEmpty) d.Ident(name.toTermName) else d.Select(qual.get, name.toTypeName)
-      val fun = if (tparams.size == 0) select else TypeApply(select, tparams.toList)
-      ApplySeq(fun, argss).withPosition
-    }
-  }
-
+  /*
   object Param extends ParamHelper {
-    def apply(mods: Seq[Tree], name: String, tpe: Option[TypeTree], default: Option[Tree]): Tree = {
-      d.ValDef(name.toTermName, tpe.getOrElse(d.TypeTree()), getOrEmpty(default)).withMods(fromMods(mods)).withFlags(Flags.TermParam).withPosition
-    }
-
-    def unapply(tree: Tree): Option[(Seq[Tree], String, Option[TypeTree], Option[Tree])] = tree match {
+    def unapply(tree: Tree): Option[(Mods, String, Option[TypeTree], Option[Tree])] = tree match {
       case valdef @ c.ValDef(name, tpe, _) =>
         val tpeOpt = if (tpe == d.TypeTree()) None else Some(tpe)
         val defaultOpt = if (valdef.rhs == d.EmptyTree) None else Some(valdef.rhs)
-        Some((toMods(valdef.mods), name.toString, tpeOpt, defaultOpt))
+        Some((new Modifiers(valdef.mods), name.toString, tpeOpt, defaultOpt))
       case _ => None
     }
-  }
+  }*/
 
-  object TypeParam extends TypeParamHelper {
-    def apply(mods: Seq[Tree], name: String, tparams: Seq[TypeTree], tboundsOpt: Option[TypeTree], cbounds: Seq[TypeTree]): TypeTree = {
-      val tbounds = tboundsOpt.getOrElse(d.TypeBoundsTree(d.EmptyTree, d.EmptyTree)).asInstanceOf[d.TypeBoundsTree]
-      val inner =
-        if (cbounds.size == 0) tbounds
-        else d.ContextBounds(tbounds, cbounds.toList.map(d.AppliedTypeTree(_, d.Ident(name.toTypeName))))
+}
 
-      val body =
-        if (tparams.size == 0) inner
-        else d.PolyTypeTree(tparams.toList.asInstanceOf[List[d.TypeDef]], inner)
+class TypeToolbox(enclosingPosition: Position)(implicit ctx: Context) extends Toolbox(enclosingPosition)(ctx) with TTbox {
+  type Type = Types.Type
 
-      d.TypeDef(name.toTypeName, body).withMods(fromMods(mods)).withPosition
-    }
-  }
+  def =:=(tp1: Type, tp2: Type): Boolean = ???
+  def <:<(tp1: Type, tp2: Type): Boolean = ???
+  def typeOf(path: String): Type = ???
 
-  object Self extends SelfHelper {
-    def apply(name: String, tpe: TypeTree): Tree =
-      d.ValDef(name.toTermName, tpe, d.EmptyTree).withPosition
-
-    def apply(name: String): Tree =
-      d.ValDef(name.toTermName, d.TypeTree(), d.EmptyTree).withPosition
-
-    def unapply(tree: Tree): Option[(String, Option[TypeTree])] = tree match {
-      case c.ValDef(name, tp, _)  =>
-        val tpOpt = if (tp == d.TypeTree()) None else Some(tp)
-        Some((name.toString, tpOpt))
-      case _ =>  None
-    }
-  }
-
-  // types
-  object TypeIdent extends TypeIdentHelper {
-    def apply(name: String): TypeTree = d.Ident(name.toTypeName).withPosition
-  }
-
-  object TypeSelect extends TypeSelectHelper {
-    def apply(qual: Tree, name: String): TypeTree = d.Select(qual, name.toTypeName).withPosition
-  }
-
-  object TypeSingleton extends TypeSingletonHelper {
-    def apply(ref: Tree): TypeTree = d.SingletonTypeTree(ref).withPosition
-  }
-
-  object TypeApply extends TypeApplyHelper {
-    def apply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree = d.AppliedTypeTree(tpe, args.toList).withPosition
-  }
-
-  object TypeApplyInfix extends TypeApplyInfixHelper {
-    def apply(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree = d.InfixOp(lhs, d.Ident(op.toTypeName), rhs).withPosition
-  }
-
-  object TypeFunction extends TypeFunctionHelper {
-    def apply(params: Seq[TypeTree], res: TypeTree): TypeTree = d.Function(params.toList, res).withPosition
-  }
-
-  object TypeTuple extends TypeTupleHelper {
-    def apply(args: Seq[TypeTree]): TypeTree = d.Tuple(args.toList).withPosition
-  }
-
-  object TypeAnd extends TypeAndHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.AndTypeTree(lhs, rhs).withPosition
-  }
-
-  object TypeOr extends TypeOrHelper {
-    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree = d.OrTypeTree(lhs, rhs).withPosition
-  }
-
-  object TypeRefine extends TypeRefineHelper {
-    def apply(tpe : Option[TypeTree], stats: Seq[Tree]): TypeTree =
-      d.RefinedTypeTree(tpe.getOrElse(d.EmptyTree), stats.toList).withPosition
-  }
-
-  object TypeBounds extends TypeBoundsHelper {
-    def apply(lo: Option[TypeTree], hi: Option[TypeTree]): TypeTree = {
-      require(lo.nonEmpty || hi.nonEmpty)
-      d.TypeBoundsTree(lo.getOrElse(d.EmptyTree), hi.getOrElse(d.EmptyTree)).withPosition
-    }
-  }
-
-  object TypeRepeated extends TypeRepeatedHelper {
-    def apply(tpe: TypeTree): TypeTree = d.PostfixOp(tpe, d.Ident(nme.raw.STAR)).withPosition
-  }
-
-  object TypeByName extends TypeByNameHelper {
-    def apply(tpe: TypeTree): TypeTree = d.ByNameTypeTree(tpe).withPosition
-  }
-
-  object TypeAnnotated extends TypeAnnotatedHelper {
-    def apply(tpe: TypeTree, annots: Seq[Tree]): TypeTree = {
-      require(annots.size > 0)
-      annots.tail.foldRight(d.Annotated(tpe, annots.head).withPosition) { (ann, acc) =>
-        d.Annotated(acc, ann).withPosition
-      }
-    }
-  }
-
-  // terms
   object Lit extends LitHelper {
-    def apply(value: Any): Tree = d.Literal(Constant(value)).withPosition
     def unapply(tree: Tree): Option[Any] = tree match {
       case c.Literal(Constant(v)) => Some(v)
       case _ => None
     }
   }
 
-  object Ident extends IdentHelper {
-    def apply(name: String): Tree = d.Ident(name.toTermName).withPosition
-  }
-
-  object Select extends SelectHelper {
-    def apply(qual: Tree, name: String): Tree = d.Select(qual, name.toTermName).withPosition
-  }
-
-  object This extends ThisHelper {
-    def apply(qual: String): Tree = d.This(d.Ident(qual.toTypeName)).withPosition
-    def apply(qual: Tree): Tree = d.This(qual.asInstanceOf[d.Ident]).withPosition
-  }
-
-  object Super extends SuperHelper {
-    def apply(thisp: String, superp: String): Tree =
-      d.Super(d.Ident(thisp.toTypeName), d.Ident(superp.toTypeName)).withPosition
-  }
-
-  object Interpolate extends InterpolateHelper {
-    def apply(prefix: String, parts: Seq[String], args: Seq[Tree]): Tree = {
-      val thickets =
-        for { (arg, part) <- args.zip(parts.take(args.size)) }
-          yield {
-            val expr = arg match {
-              case tree: d.Ident => tree
-              case tree => d.Block(Nil, tree)
-            }
-            d.Thicket(Lit(part), expr)
-          }
-      val segments =
-        if (parts.size > args.size)
-          thickets :+ Lit(parts.last)
-        else thickets
-
-      d.InterpolatedString(prefix.toTermName, segments.toList).withPosition
-    }
-  }
-
   object Apply extends ApplyHelper {
-    def apply(fun: Tree, args: Seq[Tree]): Tree = d.Apply(fun, args.toList).withPosition
     def unapply(tree: Tree): Option[(Tree, Seq[Tree])] = tree match {
       case c.Apply(fun, args) => Some((fun, args))
       case _ => None
     }
   }
 
+  /*
   object ApplyType extends ApplyTypeHelper {
-    def apply(fun: Tree, args: Seq[TypeTree]): Tree = d.TypeApply(fun, args.toList).withPosition
-
     def unapply(tree: Tree): Option[(Tree, Seq[TypeTree])] = tree match {
       case c.TypeApply(fun, args) => Some((fun, args))
       case _ => None
     }
   }
 
-  // a + (b, c)  =>  Infix(a, +, Tuple(b, c))
-  object Infix extends InfixHelper {
-    def apply(lhs: Tree, op: String, rhs: Tree): Tree =
-      d.Apply(d.Select(lhs, op.toTermName), List(rhs)).withPosition
-  }
-
-  object Prefix extends PrefixHelper {
-    def apply(op: String, od: Tree): Tree = d.PrefixOp(d.Ident(op.toTermName), od).withPosition
-  }
-
-  object Postfix extends PostfixHelper {
-    def apply(od: Tree, op: String): Tree = d.PostfixOp(od, d.Ident(op.toTermName)).withPosition
-  }
-
   object Assign extends AssignHelper {
-    def apply(lhs: Tree, rhs: Tree): Tree = d.Assign(lhs, rhs).withPosition
-
     def unapply(tree: Tree): Option[(Tree, Tree)] = tree match {
       case c.Assign(lhs, rhs) => Some((lhs, rhs))
       case _ => None
     }
-  }
+  } */
 
-  object Return extends ReturnHelper {
-    def apply(expr: Tree): Tree = d.Return(expr, d.EmptyTree).withPosition
-  }
-
-  object Throw extends ThrowHelper {
-    def apply(expr: Tree): Tree = d.Throw(expr).withPosition
-  }
-
-  object Ascribe extends AscribeHelper {
-    def apply(expr: Tree, tpe: Tree): Tree = d.Typed(expr, tpe).withPosition
-  }
-
-  object Annotated extends AnnotatedHelper {
-    def apply(expr: Tree, annots: Seq[Tree]): Tree = {
-      require(annots.size > 0)
-      annots.tail.foldRight(d.Annotated(expr, annots.head).withPosition) { (ann, acc) =>
-        d.Annotated(acc, ann).withPosition
-      }
-    }
-  }
-
-  object Tuple extends TupleHelper {
-    def apply(args: Seq[Tree]): Tree = d.Tuple(args.toList).withPosition
-  }
-
-  object Block extends BlockHelper {
-    def apply(stats: Seq[Tree]): Tree = {
-      if (stats.size == 0)
-        d.Block(stats.toList, d.EmptyTree).withPosition
-      else
-        d.Block(stats.init.toList, stats.last).withPosition
-    }
-  }
-
-  object If extends IfHelper {
-    def apply(cond: Tree, thenp: Tree, elsep: Option[Tree]): Tree =
-      d.If(cond, thenp, elsep.getOrElse(d.EmptyTree)).withPosition
-  }
-
-  object Match extends MatchHelper {
-    def apply(expr: Tree, cases: Seq[Tree]): Tree =
-      d.Match(expr, cases.toList.asInstanceOf[List[d.CaseDef]]).withPosition
-  }
-
-  object Case extends CaseHelper {
-    def apply(pat: Tree, cond: Option[Tree], body: Tree): Tree =
-      d.CaseDef(pat, cond.getOrElse(d.EmptyTree), body).withPosition
-  }
-
-  object Try extends TryHelper {
-    def apply(expr: Tree, cases: Seq[Tree], finallyp: Option[Tree]): Tree =
-      d.Try(expr, cases.toList.asInstanceOf[List[d.CaseDef]], finallyp.getOrElse(d.EmptyTree)).withPosition
-
-    def apply(expr: Tree, handler: Tree, finallyp: Option[Tree]): Tree =
-      d.ParsedTry(expr, handler, finallyp.getOrElse(d.EmptyTree)).withPosition
-  }
-
-  object Function extends FunctionHelper {
-    def apply(params: Seq[Tree], body: Tree): Tree =
-      d.Function(params.toList, body).withPosition
-  }
-
-  object PartialFunction extends PartialFunctionHelper {
-    def apply(cases: Seq[Tree]): Tree =
-      d.Match(d.Thicket(Nil), cases.toList.asInstanceOf[List[d.CaseDef]]).withPosition
-  }
-
-  object While extends WhileHelper {
-    def apply(expr: Tree, body: Tree): Tree = d.WhileDo(expr, body).withPosition
-  }
-
-  object DoWhile extends DoWhileHelper {
-    def apply(body: Tree, expr: Tree): Tree = d.DoWhile(body, expr).withPosition
-  }
-
-  object For extends ForHelper {
-    def apply(enums: Seq[Tree], body: Tree): Tree = ???
-  }
-
-  object GenFrom extends GenFromHelper {
-    def apply(pat: Tree, rhs: Tree): Tree = ???
-  }
-
-  object GenAlias extends GenAliasHelper {
-    def apply(pat: Tree, rhs: Tree): Tree = ???
-  }
-
-  object Guard extends GuardHelper {
-    def apply(cond: Tree): Tree = ???
-  }
-
-  object Yield extends YieldHelper {
-    def apply(expr: Tree): Tree = ???
-  }
-
-  // can be InitCall or AnonymClass
-  object New extends NewHelper {
-    def apply(tpe: Tree): Tree = d.New(tpe).withPosition
-  }
-
-  object Named extends NamedHelper {
-    def apply(name: String, expr: Tree): Tree =
-      d.NamedArg(name.toTermName, expr).withPosition
-  }
-
-  object Repeated extends RepeatedHelper {
-    def apply(expr: Tree): Tree =
-      d.Typed(expr, d.Ident(tpnme.WILDCARD_STAR)).withPosition
-  }
-
-  // patterns
-  object Bind extends BindHelper {
-    def apply(name: String, expr: Tree): Tree =
-      d.Bind(name.toTermName, expr).withPosition
-  }
-
-  object Alternative extends AlternativeHelper {
-    def apply(lhs: Tree, rhs: Tree): Tree =
-      d.Alternative(List(lhs, rhs)).withPosition
-  }
-
-  // importees
-  object Import extends ImportHelper {
-    def apply(items: Seq[Tree]): Tree =
-      if (items.size == 1)
-        items(0).withPosition
-      else
-        d.Thicket(items.toList).withPosition
-  }
-
-  object ImportItem extends ImportItemHelper {
-    def apply(ref: Tree, importees: Seq[Tree]): Tree =
-      d.Import(ref, importees.toList).withPosition
-  }
-
-  object ImportName extends ImportNameHelper {
-    def apply(name: String): Tree = d.Ident(name.toTermName).withPosition
-  }
-
-  object ImportRename extends ImportRenameHelper {
-    def apply(from: String, to: String): Tree =
-      d.Thicket(d.Ident(from.toTermName), d.Ident(to.toTermName)).withPosition
-  }
-
-  object ImportHide extends ImportHideHelper {
-    def apply(name: String): Tree =
-      d.Thicket(d.Ident(name.toTermName), d.Ident(nme.WILDCARD)).withPosition
-  }
-
-  // modifiers
-  object Mod extends ModHelper {
-
-    object Private extends PrivateHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class PrivateTree(within: String) extends d.Tree
-
-      def apply(within: String): Tree = PrivateTree(within)
-      def unapply(tree: Tree): Option[String] = tree match {
-        case PrivateTree(within) => Some(within)
-        case _                   => None
-      }
-    }
-
-    object Protected extends ProtectedHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class ProtectedTree(within: String) extends d.Tree
-
-      def apply(within: String): Tree = ProtectedTree(within)
-      def unapply(tree: Tree): Option[String] = tree match {
-        case ProtectedTree(within) => Some(within)
-        case _                     => None
-      }
-    }
-
-    object Val extends ValHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class ValTree() extends d.Tree
-
-      def apply(): Tree = ValTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[ValTree]
-    }
-
-    object Var extends VarHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class VarTree() extends d.Tree
-
-      def apply(): Tree = VarTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[VarTree]
-    }
-
-    object Implicit extends ImplicitHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class ImplicitTree() extends d.Tree
-
-      def apply(): Tree = ImplicitTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[ImplicitTree]
-    }
-
-    object Final extends FinalHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class FinalTree() extends d.Tree
-
-      def apply(): Tree = FinalTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[FinalTree]
-    }
-
-    object Sealed extends SealedHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class SealedTree() extends d.Tree
-
-      def apply(): Tree = SealedTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[SealedTree]
-    }
-
-    object Override extends OverrideHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class OverrideTree() extends d.Tree
-
-      def apply(): Tree = OverrideTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[OverrideTree]
-    }
-
-    object Abstract extends AbstractHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class AbstractTree() extends d.Tree
-
-      def apply(): Tree = AbstractTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[AbstractTree]
-    }
-
-    object Lazy extends LazyHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class LazyTree() extends d.Tree
-
-      def apply(): Tree = LazyTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[LazyTree]
-    }
-
-    object Inline extends InlineHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class InlineTree() extends d.Tree
-
-      def apply(): Tree = InlineTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[InlineTree]
-    }
-
-    object Type extends TypeHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class TypeTree() extends d.Tree
-
-      def apply(): Tree = TypeTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[TypeTree]
-    }
-
-    object Case extends CaseHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class CaseTree() extends d.Tree
-
-      def apply(): Tree = CaseTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[CaseTree]
-    }
-
-    object Contravariant extends ContravariantHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class ContravariantTree() extends d.Tree
-
-      def apply(): Tree = ContravariantTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[ContravariantTree]
-    }
-
-    object Covariant extends CovariantHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class CovariantTree() extends d.Tree
-
-      def apply(): Tree = CovariantTree()
-      def unapply(tree: Tree): Boolean = tree.isInstanceOf[CovariantTree]
-    }
-
-    object Annot extends AnnotHelper {
-      // Dummy trees to retrofit Dotty AST
-      private case class AnnotTree(body: Tree) extends d.Tree
-
-      def apply(body: Tree): Tree = AnnotTree(body)
-      def unapply(tree: Tree): Option[Tree] = tree match {
-        case AnnotTree(body) => Some(body)
-        case _               => None
-      }
-    }
-  }
 }

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -435,7 +435,7 @@ class StructToolbox(enclosingPosition: Position)(implicit ctx: Context) extends 
   object Object extends ObjectHelper {
     def unapply(tree: Tree): Option[(Mods, String, Seq[Tree], Option[Tree], Seq[Tree])] = tree match {
       case obj @ d.ModuleDef(name, templ @ c.Template(constr, parents, self: d.ValDef, body)) =>
-        val selfOpt = if (self.name == nme.WILDCARD || self.isEmpty) None else Some(Self(self.name.toString, self.tpt))
+        val selfOpt = if (self == d.EmptyValDef) None else Some(Self(self.name.toString, self.tpt))
         Some((obj.mods, name.toString, parents, selfOpt, templ.body))
       case _ => None
     }
@@ -451,7 +451,7 @@ class StructToolbox(enclosingPosition: Position)(implicit ctx: Context) extends 
             tparams = tps
             Some(PrimaryCtor(pctor.mods, paramss))
         }
-        val selfOpt = if (self.name == nme.WILDCARD && self.tpt == d.TypeTree()) None else Some(Self(self.name.toString, self.tpt))
+        val selfOpt = if (self == d.EmptyValDef) None else Some(Self(self.name.toString, self.tpt))
         Some((cdef.mods, name.toString, tparams, ctor, tparams, selfOpt, templ.body))  // TODO: parents
       case _ => None
     }

--- a/src/main/scala/gestalt/dotty/Expander.scala
+++ b/src/main/scala/gestalt/dotty/Expander.scala
@@ -52,7 +52,7 @@ object Expander {
         (name.toString, parts, pats)
     }
     val strs = for(Literal(Constant(v: String)) <- parts) yield v
-    expand(new Toolbox(tree.pos))(tag, strs, args, !isTerm)
+    expand(new Toolbox(tree.pos))(tag, tree, strs, args, !isTerm)
   }
 
   /** Expand annotation macros */

--- a/src/main/scala/gestalt/dotty/Expander.scala
+++ b/src/main/scala/gestalt/dotty/Expander.scala
@@ -52,7 +52,7 @@ object Expander {
         (name.toString, parts, pats)
     }
     val strs = for(Literal(Constant(v: String)) <- parts) yield v
-    expand(new DottyToolbox(tree.pos))(tag, strs, args, !isTerm)
+    expand(new Toolbox(tree.pos))(tag, strs, args, !isTerm)
   }
 
   /** Expand annotation macros */
@@ -72,7 +72,7 @@ object Expander {
           val mods1 = mdef.mods.withAnnotations(mdef.mods.annotations.filter(_ ne ann))
           mdef.withMods(mods1)
         }
-        val result = impl.invoke(null, new DottyToolbox(ann.pos), ann, expandee).asInstanceOf[untpd.Tree]
+        val result = impl.invoke(null, new StructToolbox(ann.pos), ann, expandee).asInstanceOf[untpd.Tree]
         Some(result)
       case _ =>
         None
@@ -91,7 +91,7 @@ object Expander {
       val impl = moduleClass.getDeclaredMethods().find(_.getName == method.toString).get
       impl.setAccessible(true)
 
-      val trees  = new DottyToolbox(tree.pos) :: prefix :: targs ++ argss.flatten
+      val trees  = new TypeToolbox(tree.pos) :: prefix :: targs ++ argss.flatten
       impl.invoke(null, trees: _*).asInstanceOf[untpd.Tree]
     case _ =>
       ctx.warning(s"Unknown macro expansion: $tree")

--- a/src/main/scala/gestalt/package.scala
+++ b/src/main/scala/gestalt/package.scala
@@ -27,10 +27,10 @@ package object gestalt {
    *
    *  This method is intended to be reflectively called by the compiler
    */
-  def expand(t: Toolbox)(label: String, parts: List[String], unquotes: List[t.Tree], isPattern: Boolean): t.Tree = {
+  def expand(t: Toolbox)(label: String, tree: t.Tree, parts: List[String], unquotes: List[t.Tree], isPattern: Boolean): t.Tree = {
     val quote      = new Quasiquote(t, "toolbox")
     val argsTyped  = unquotes.asInstanceOf[List[quote.t.Tree]]
-    quote.expand(label, parts, argsTyped, isPattern).asInstanceOf[t.Tree]
+    quote.expand(label, tree.asInstanceOf[quote.t.Tree], parts, argsTyped, isPattern).asInstanceOf[t.Tree]
   }
 
 }


### PR DESCRIPTION
Now the split is done and the test set pass -- except one cheat to change the definition of one annotation macro in order for it to compile. I think it's possible to do better without the cheat, I'll improve tomorrow.

Modifiers are refactored completely, they are no longer trees. The usage of modifiers for macro writers will be much simpler.

Review @valdisxp1 .