### PR TITLE
Quasiquotes: fix private and protected mods

### DIFF
--- a/macros/src/main/scala/gestalt/macros/Annotations.scala
+++ b/macros/src/main/scala/gestalt/macros/Annotations.scala
@@ -15,18 +15,19 @@ class main extends StaticAnnotation {
 
 class addFields extends StaticAnnotation {
   inline def apply(defn: Any): Any = meta {
-    val q"class $name { ..$stats }" = defn
-    val main = q"""
-      ..$stats
-      private def a = 1
-      private[this] def b = 2
-      private[pack] def c = 3
+    val q"$mods object $name { ..${stats:Seq[toolbox.Tree]} }" = defn
+    val additional = Seq(
+      q"private def a = 1",
+      q"private[this] def b = 2",
+      q"private[pack] def c = 3",
 
-      protected def a1 = 1
-      protected[this] def b1 = 2
-      protected[pack] def c1 = 3
-    """
-    q"class $name { $main }"
+      q"protected def a1 = 1",
+      q"protected[this] def b1 = 2",
+      q"protected[pack] def c1 = 3",
+
+      q"def all = List(a,b,c,a1,b1,c1)"
+    )
+    q"$mods object $name { ${toolbox.Block(stats ++ additional)} }"
   }
 }
 

--- a/macros/src/main/scala/gestalt/macros/Annotations.scala
+++ b/macros/src/main/scala/gestalt/macros/Annotations.scala
@@ -16,7 +16,7 @@ class main extends StaticAnnotation {
 class addFields extends StaticAnnotation {
   inline def apply(defn: Any): Any = meta {
     val q"$mods object $name { ..${stats:Seq[toolbox.Tree]} }" = defn
-    val additional = Seq(
+    val additional: Seq[toolbox.Tree] = Seq(
       q"private def a = 1",
       q"private[this] def b = 2",
       q"private[pack] def c = 3",
@@ -25,9 +25,9 @@ class addFields extends StaticAnnotation {
       q"protected[this] def b1 = 2",
       q"protected[pack] def c1 = 3",
 
-      q"def all = List(a,b,c,a1,b1,c1)"
+      q"def all = List(a,b,c, a1,b1,c1)"
     )
-    q"$mods object $name { ${toolbox.Block(stats ++ additional)} }"
+    q"$mods object $name { ..${stats ++ additional} }"
   }
 }
 

--- a/macros/src/main/scala/gestalt/macros/Annotations.scala
+++ b/macros/src/main/scala/gestalt/macros/Annotations.scala
@@ -13,6 +13,23 @@ class main extends StaticAnnotation {
   }
 }
 
+class addFields extends StaticAnnotation {
+  inline def apply(defn: Any): Any = meta {
+    val q"class $name { ..$stats }" = defn
+    val main = q"""
+      ..$stats
+      private def a = 1
+      private[this] def b = 2
+      private[pack] def c = 3
+
+      protected def a1 = 1
+      protected[this] def b1 = 2
+      protected[pack] def c1 = 3
+    """
+    q"class $name { $main }"
+  }
+}
+
 class replace extends StaticAnnotation {
   inline def apply(defn: Any): Any = meta {
     q"object UnrelatedObject{ def aPrimeNumber = 29 }"

--- a/macros/src/test/scala/gestalt/macros/AnnotationMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/AnnotationMacroTest.scala
@@ -1,5 +1,4 @@
 package pack {
-  import _root_.addFields
   @addFields object Nice
 }
 

--- a/macros/src/test/scala/gestalt/macros/AnnotationMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/AnnotationMacroTest.scala
@@ -1,3 +1,8 @@
+package pack {
+  import _root_.addFields
+  @addFields class Nice
+}
+
 class AnnotationMacroTest extends TestSuite {
   test("main") {
     @main object Test {
@@ -12,6 +17,17 @@ class AnnotationMacroTest extends TestSuite {
 
     assert(UnrelatedObject.aPrimeNumber == 29)
   }
+
+  test("addFields"){
+    import pack.Nice
+    assert(new Nice().a == 1)
+    assert(new Nice().b == 2)
+    assert(new Nice().c == 3)
+    assert(new Nice().a1 == 1)
+    assert(new Nice().b1 == 2)
+    assert(new Nice().c1 == 3)
+  }
+
 
   /*
   test("data") {

--- a/macros/src/test/scala/gestalt/macros/AnnotationMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/AnnotationMacroTest.scala
@@ -1,6 +1,6 @@
 package pack {
   import _root_.addFields
-  @addFields class Nice
+  @addFields object Nice
 }
 
 class AnnotationMacroTest extends TestSuite {
@@ -20,12 +20,7 @@ class AnnotationMacroTest extends TestSuite {
 
   test("addFields"){
     import pack.Nice
-    assert(new Nice().a == 1)
-    assert(new Nice().b == 2)
-    assert(new Nice().c == 3)
-    assert(new Nice().a1 == 1)
-    assert(new Nice().b1 == 2)
-    assert(new Nice().c1 == 3)
+    assert(Nice.all == List(1,2,3,1,2,3))
   }
 
 

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -15,14 +15,16 @@ import d.modsDeco
 import util.Positions
 import Positions.Position
 
-import scala.collection.mutable.ListBuffer
-
 object ModsHelper {
   // TODO: valDefContext: (1) caseClassParam (2) self (3) methodParam (4) classParam
   def toDotty(tbMods: Mods[d.Tree]): d.Modifiers = {
+    val privateWithin = tbMods.privateWithin match {
+      case "this" | "" => tpnme.EMPTY
+      case named => named.toTypeName
+    }
     var dottyMods = d.Modifiers(
       annotations = tbMods.annotations,
-      privateWithin = tbMods.privateWithin.toTypeName)
+      privateWithin = privateWithin)
 
     if (tbMods.is(flags.Private))
       dottyMods =


### PR DESCRIPTION
- added test for adding private, protected and public defs.
- fixed issue with `private[this]` and `protected[this]`. Previously it was failing in the Namer with "no enclosing class or object is named this". The issue would only appear when the macro is actually expanded and reaches the Typer.

#26 