### PR TITLE
add assembly plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val gestaltSetting = Seq(
   libraryDependencies ++= Seq(
     "org.scalameta" %% "scalameta" % metaVersion,
     "org.scalatest" %% "scalatest" % "3.0.0" % "test",
-    "me.fengy" % "dotty_2.11" % dottyVersion
+    "me.fengy" % "dotty_2.11" % dottyVersion % "provided"
   ),
 
   credentials += Credentials(Path.userHome / ".sbt" / ".credentials"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")


### PR DESCRIPTION
Add assembly plugin so that it's possible to run `sbt assembly` to create bundled jars.

The jars can in turn passed to our dotc to compile macros in command line.

```
./bin/dotc -cp gestalt-assembly-0.1.1.jar   macro.scala
```
