### PR TITLE
Def macros: varargs

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -21,11 +21,16 @@ object plusObject {
     }
   }
 
-  inline def varargs(items: Int*): Int = meta {
-    //TODO somehow read the varargs value
-//    items.reduceLeft((a,b)=>q"$a + $b")
+  inline def varargs(tped: Int*): Int = meta {
+    val q"$items: $_" = tped
     println(">>>"+items)
-    q"1"
+    items match {
+      case toolbox.SeqLiteral(items:Seq[toolbox.Tree]) =>
+        println("!!!"+items)
+        items.reduceLeft((a, b) => q"$a + $b")
+      case other =>
+        q"$other.reduce((a:Int,b:Int)=> a + b)"
+    }
   }
 }
 

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -20,6 +20,13 @@ object plusObject {
         toolbox.Lit(null)
     }
   }
+
+  inline def varargs(items: Int*): Int = meta {
+    //TODO somehow read the varargs value
+//    items.reduceLeft((a,b)=>q"$a + $b")
+    println(">>>"+items)
+    q"1"
+  }
 }
 
 

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -28,8 +28,8 @@ object plusObject {
       case toolbox.SeqLiteral(items:Seq[toolbox.Tree]) =>
         println("!!!"+items)
         items.reduceLeft((a, b) => q"$a + $b")
-      case other =>
-        q"$other.reduce((a:Int,b:Int)=> a + b)"
+      case _ =>
+        q"$items.reduce((a:Int,b:Int)=> a + b)"
     }
   }
 }

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -24,10 +24,20 @@ object plusObject {
   inline def varargs(tped: Int*): Int = meta {
     val q"$items: $_" = tped
     items match {
-      case toolbox.SeqLiteral(items:Seq[toolbox.Tree]) =>
+      case toolbox.SeqLiteral(items: Seq[toolbox.Tree]) =>
         items.reduceLeft((a, b) => q"$a + $b")
       case _ =>
         q"$items.reduce((a:Int,b:Int)=> a + b)"
+    }
+  }
+
+  inline def deconstructApply(items: Any): Int = meta {
+    items match {
+      case toolbox.Apply(prefix: toolbox.Tree, items: Seq[toolbox.Tree]) =>
+        items.reduceLeft((a, b) => q"$a + $b")
+      case _ =>
+        toolbox.error("expected application of Ints",items)
+        toolbox.Lit(null)
     }
   }
 }

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -23,10 +23,8 @@ object plusObject {
 
   inline def varargs(tped: Int*): Int = meta {
     val q"$items: $_" = tped
-    println(">>>"+items)
     items match {
       case toolbox.SeqLiteral(items:Seq[toolbox.Tree]) =>
-        println("!!!"+items)
         items.reduceLeft((a, b) => q"$a + $b")
       case _ =>
         q"$items.reduce((a:Int,b:Int)=> a + b)"

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -11,6 +11,11 @@ class DefMacroTest extends TestSuite {
 
     assert(plusObject.poly(3, 5) == 8)
     assert(plusObject.poly("3", 5) == 8)
+
+    assert(plusObject.varargs(1, 2, 5) == 8)
+    assert(plusObject.varargs(Seq(1, 2, 5):_*) == 8)
+    assert(plusObject.varargs(3, 5) == 8)
+    assert(plusObject.varargs(8) == 8)
   }
   test("plus") {
     val p = new plus

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -15,7 +15,9 @@ class DefMacroTest extends TestSuite {
     val five = 5
     assert(plusObject.varargs(1, 1 + 1, five) == 8)
     assert(plusObject.varargs(1, 2, 5) == 8)
-    assert(plusObject.varargs(Seq(1, 2, 5):_*) == 8)
+//    assert(plusObject.varargs(Seq(1, 2, 5):_*) == 8)
+    val ints = Seq(1, 2, 5)
+    assert(plusObject.varargs(ints:_*) == 8)
     assert(plusObject.varargs(3, 5) == 8)
     assert(plusObject.varargs(8) == 8)
   }

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -112,6 +112,14 @@ class DefMacroTest extends TestSuite {
     assert(PlusObj.plus(3,5) == 8)
   }
 
+  test("deconstructApply") {
+    import plusObject.deconstructApply
+    def fun(x: Int, y: Int, z: Int) = ???
+    assert(deconstructApply(Seq(1, 2, 1, 3)) == 7)
+    assert(deconstructApply(List[Int](1, 2, 1, 3)) == 7)
+    assert(deconstructApply(fun(1, 2, 4)) == 7)
+  }
+
   test("def with type parameters") {
     assert(scope.is[String]("hello"))
     assert(!scope.both[String, List[Int]]("hello"))

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -12,6 +12,8 @@ class DefMacroTest extends TestSuite {
     assert(plusObject.poly(3, 5) == 8)
     assert(plusObject.poly("3", 5) == 8)
 
+    val five = 5
+    assert(plusObject.varargs(1, 1 + 1, five) == 8)
     assert(plusObject.varargs(1, 2, 5) == 8)
     assert(plusObject.varargs(Seq(1, 2, 5):_*) == 8)
     assert(plusObject.varargs(3, 5) == 8)

--- a/src/main/scala/gestalt/Toolbox.scala
+++ b/src/main/scala/gestalt/Toolbox.scala
@@ -263,6 +263,11 @@ trait TypeToolbox extends Toolbox { t =>
   def <:<(tp1: Type, tp2: Type): Boolean
   def typeOf(path: String): Type
 
+  val Ascribe: AscribeHelper
+  trait AscribeHelper {
+    def unapply(arg: Tree): Option[(Tree, TypeTree)]
+  }
+
   val Lit: LitHelper
   trait LitHelper {
     def unapply(tree: Tree): Option[Any]

--- a/src/main/scala/gestalt/Toolbox.scala
+++ b/src/main/scala/gestalt/Toolbox.scala
@@ -268,6 +268,11 @@ trait TypeToolbox extends Toolbox { t =>
     def unapply(arg: Tree): Option[(Tree, TypeTree)]
   }
 
+  val SeqLiteral: SeqLiteralHelper
+  trait SeqLiteralHelper {
+    def unapply(tree: Tree): Option[Seq[Tree]]
+  }
+
   val Lit: LitHelper
   trait LitHelper {
     def unapply(tree: Tree): Option[Any]

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -485,6 +485,13 @@ class TypeToolbox(enclosingPosition: Position)(implicit ctx: Context) extends To
     }
   }
 
+  object SeqLiteral extends SeqLiteralHelper {
+    def unapply(tree: Tree): Option[Seq[Tree]] = tree match {
+      case c.SeqLiteral(elems,_) => Some(elems)
+      case _ => None
+    }
+  }
+
   /*
   object ApplyType extends ApplyTypeHelper {
     def unapply(tree: Tree): Option[(Tree, Seq[TypeTree])] = tree match {

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -463,6 +463,13 @@ class TypeToolbox(enclosingPosition: Position)(implicit ctx: Context) extends To
   def <:<(tp1: Type, tp2: Type): Boolean = ???
   def typeOf(path: String): Type = ???
 
+  object Ascribe extends AscribeHelper {
+    def unapply(tree: Tree): Option[(Tree, TypeTree)] = tree match {
+      case c.Typed(expr, tpt) => Some((expr, tpt))
+      case _ => None
+    }
+  }
+
   object Lit extends LitHelper {
     def unapply(tree: Tree): Option[Any] = tree match {
       case c.Literal(Constant(v)) => Some(v)
@@ -472,6 +479,7 @@ class TypeToolbox(enclosingPosition: Position)(implicit ctx: Context) extends To
 
   object Apply extends ApplyHelper {
     def unapply(tree: Tree): Option[(Tree, Seq[Tree])] = tree match {
+      case c.Apply(fun, Seq(c.Typed(c.SeqLiteral(args, _), _))) => Some((fun, args))
       case c.Apply(fun, args) => Some((fun, args))
       case _ => None
     }


### PR DESCRIPTION
- Added `Ascribe` to `TypedToolbox`. For some reason **every** argument for varargs is wrapped in in an ascription. Need to extract from it to do anything.
- Added `SeqLiteral` to `TypedToolbox`. The varargs can be either a collection or a sequence literal, therefore macro implementation always gets it as a single argument. 
The only other alternative I can think of is to look at `(... 1,3,4,5)` as `Seq[Int].apply(1,3,4,5)` similar to what Java does with arrays and their varargs. Then items could be extracted with `Apply`, `TypeApply` and `Ident`. This looked like too much magic to me.
- Added a special case to `Apply` extractor to handle varargs. 
- Tests for all three cases. 