### PR TITLE
Fix #38: remove the accidental complexity with varargs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val metaVersion = "1.5.0.585"
+lazy val metaVersion = "1.6.0"
 lazy val dottyVersion = "0.2.2-SNAPSHOT"
 
 lazy val common = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ lazy val dottyVersion = "0.2.2-SNAPSHOT"
 
 lazy val common = Seq(
   resolvers ++= Seq(
-    Resolver.bintrayIvyRepo("scalameta", "maven"),
-    Resolver.sonatypeRepo("snapshots")
+    Resolver.sonatypeRepo("snapshots"),
+    Resolver.sonatypeRepo("releases")
   )
 )
 

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -21,12 +21,11 @@ object plusObject {
     }
   }
 
-  inline def varargs(tped: Int*): Int = meta {
-    val q"$items: $_" = tped
+  inline def varargs(items: Int*): Int = meta {
     items match {
       case toolbox.SeqLiteral(items: Seq[toolbox.Tree]) =>
         items.reduceLeft((a, b) => q"$a + $b")
-      case _ =>
+      case q"$items: $_" =>
         q"$items.reduce((a:Int,b:Int)=> a + b)"
     }
   }

--- a/src/main/scala/gestalt/Quasiquote.scala
+++ b/src/main/scala/gestalt/Quasiquote.scala
@@ -8,7 +8,7 @@ object Quasiquote {
   type QuoteLabel = String
 
   // term dialect suffices the purpose, no need for pattern dialect
-  val quasiquoteTermDialect = m.Dialect.forName("QuasiquoteTerm(Dotty, Multi)")
+  val quasiquoteTermDialect = m.dialects.Dotty.copy(allowTermUnquotes = true, allowMultilinePrograms = true)
 
   private val StringContextName = "StringContext"
   private val ApplyName = "apply"

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -487,7 +487,7 @@ class TypeToolbox(enclosingPosition: Position)(implicit ctx: Context) extends To
 
   object SeqLiteral extends SeqLiteralHelper {
     def unapply(tree: Tree): Option[Seq[Tree]] = tree match {
-      case c.SeqLiteral(elems,_) => Some(elems)
+      case c.Typed(c.SeqLiteral(elems,_), _) => Some(elems)
       case _ => None
     }
   }


### PR DESCRIPTION
remove the accidental complexity with varargs, now the macro writers either get a SeqLiteral tree, or a `Typed` tree, which is more regular.