### PR TITLE
fix #48: implement and test initial semantic API

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -138,3 +138,16 @@ object Locations {
   }
 }
 
+object CaseInfo {
+  def fields[T]: List[String] = meta {
+    val tp = toolbox.typeOf(T)
+    if (!toolbox.isCaseClass(tp)) {
+      toolbox.error("Not a case class", T)
+      q"scala.Nil"
+    }
+    else {
+      val fieldTrees = toolbox.caseFields(tp).map(m => toolbox.Lit(toolbox.name(m)))
+      q"List(..$fieldTrees)"
+    }
+  }
+}

--- a/macros/src/main/scala/gestalt/macros/TypeToolbox.scala
+++ b/macros/src/main/scala/gestalt/macros/TypeToolbox.scala
@@ -1,0 +1,70 @@
+import scala.gestalt._
+
+object TypeToolbox {
+  /** are the two types equal? */
+  def =:=[A, B]: Boolean = meta {
+    val tpA = toolbox.typeOf(A)
+    val tpB = toolbox.typeOf(B)
+    val res = toolbox.=:=(tpA, tpB)
+    toolbox.Lit(res)
+  }
+
+  /** is `tp1` a subtype of `tp2` */
+  def <:<[A, B]: Boolean = meta {
+    val tpA = toolbox.typeOf(A)
+    val tpB = toolbox.typeOf(B)
+    val res = toolbox.<:<(tpA, tpB)
+    toolbox.Lit(res)
+  }
+
+  /** returning a type referring to a type definition */
+  def typeRef[Expected](path: String): Boolean = meta {
+    val toolbox.Lit(p: String) = path
+    val exp = toolbox.typeOf(Expected)
+    val tp = toolbox.typeRef(p)
+    val res = toolbox.=:=(tp, exp)
+    // println(s"typeRef: $exp   <->  $tp")
+    toolbox.Lit(res)
+  }
+
+  /** returning a type referring to a value definition */
+  def termRef[Expected](path: String): Boolean = meta {
+    val toolbox.Lit(p: String) = path
+    val exp = toolbox.typeOf(Expected)
+    val tp = toolbox.termRef(p)
+    // println(s"typeRef: $exp   <->  $tp")
+    val res = toolbox.=:=(tp, exp)
+    toolbox.Lit(res)
+  }
+
+  /** type associated with the tree */
+  def typeOf[T, Expected](a: T): Boolean = meta {
+    val tp = toolbox.typeOf(a)
+    val res = toolbox.=:=(tp, toolbox.typeOf(Expected))
+    toolbox.Lit(res)
+  }
+
+  /** does the type refer to a case class? */
+  def isCaseClass[A]: Boolean = meta {
+    val tp = toolbox.typeOf(A)
+    val res = toolbox.isCaseClass(tp)
+    toolbox.Lit(res)
+  }
+
+  /** val fields of a case class Type -- only the ones declared in primary constructor */
+  def caseFields[T]: List[String] = meta {
+    val tp = toolbox.typeOf(T)
+    val fieldTrees = toolbox.caseFields(tp).map(m => toolbox.Lit(toolbox.name(m)))
+    q"List(..$fieldTrees)"
+  }
+
+  /** type of a member with respect to a prefix */
+  def asSeenFrom[Prefix, Expected](mem: String): Boolean = meta {
+    val toolbox.Lit(fd: String) = mem
+    val expectedTp = toolbox.typeOf(Expected)
+    val prefixTp = toolbox.typeOf(Prefix)
+    val fieldTp = toolbox.asSeenFrom(toolbox.field(prefixTp, fd).get, prefixTp)
+    val res = toolbox.<:<(fieldTp, expectedTp)
+    toolbox.Lit(res)
+  }
+}

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -173,4 +173,14 @@ class DefMacroTest extends TestSuite {
     assert(pos.fileName == "DefMacroTest.scala")
     assert(pos.line == 171) // starts from 0
   }
+
+  test("case info") {
+    import CaseInfo._
+    case class Student(name: String, age: Int)
+    assert(fields[Student] == List("name", "age"))
+
+    // compile-time error message: Not a case class
+    // class Teacher(name: String, age: Int)
+    // assert(fields[Teacher] == List())
+  }
 }

--- a/macros/src/test/scala/gestalt/macros/Driver.scala
+++ b/macros/src/test/scala/gestalt/macros/Driver.scala
@@ -8,6 +8,7 @@ object Driver {
     new AnnotationMacroTest
     new DefMacroTest
     new QuasiquoteTest
+    new TypeToolboxTest
 
     var success = false
     var total = 0

--- a/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
+++ b/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
@@ -81,5 +81,16 @@ class TypeToolboxTest extends TestSuite {
 
     val m = new Child
     assert(asSeenFrom[m.type, m.Inner]("x"))
+
+    trait Box {
+      type T
+      val x: T
+    }
+    class InBox extends Box {
+      type T = Int
+      val x = 3
+    }
+    val box = new InBox
+    assert(asSeenFrom[box.type, Int]("x"))
   }
 }

--- a/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
+++ b/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
@@ -1,0 +1,85 @@
+import scala.collection.immutable.Seq
+
+import dotty.tools._
+import dotc.core.Contexts._
+
+import scala.gestalt._
+
+class TypeToolboxTest extends TestSuite {
+  import TypeToolbox._
+
+  type Age = Int
+
+  test("=:=") {
+    assert(=:=[Nil.type, Nil.type])
+    assert(=:=[Int, Int])
+    assert(! =:=[Int, String])
+    assert(=:=[Int, Age])
+  }
+
+  test("<:<") {
+    assert(<:<[Int, Int])
+    assert(<:<[Age, Int])
+    assert(<:<[None.type, Option[Int]])
+    assert(<:<[Nil.type, List[Int]])
+    assert(! <:<[Int, String])
+
+    val a = 5
+    assert(<:<[3, Int])
+    assert(<:<[a.type, Int])
+  }
+
+  test("typeRef") {
+    assert(typeRef[String]("java.lang.String"))
+    assert(typeRef[String]("scala.Predef.String"))
+    assert(typeRef[Int]("scala.Int"))
+    assert(typeRef[Boolean]("scala.Boolean"))
+  }
+
+  test("termRef") {
+    assert(termRef[None.type]("scala.None"))
+    assert(termRef[Nil.type]("scala.Nil"))
+  }
+
+  test("isCaseClass") {
+    case class Student(name: String, age: Int)
+    class Teacher(name: String, age: Int)
+    trait Staff
+    assert(isCaseClass[Student])
+    assert(!isCaseClass[Teacher])
+    assert(!isCaseClass[Staff])
+
+  }
+
+  test("caseFields") {
+    case class Student(name: String, age: Int)
+    case class Teacher(name: String, age: Int) {
+      val school: String = "EPFL"
+      var salary: Int = 20000
+    }
+
+    assert(caseFields[Student] == List("name", "age"))
+    assert(caseFields[Teacher] == List("name", "age"))
+  }
+
+  test("asSeenFrom") {
+    case class M[T](x: T)
+    val a = new M(4)
+
+    assert(asSeenFrom[a.type, Int]("x"))
+
+
+    trait Base {
+      val x: InBase
+      trait InBase
+    }
+
+    class Child extends Base {
+      val x: Inner = new Inner
+      class Inner extends InBase
+    }
+
+    val m = new Child
+    assert(asSeenFrom[m.type, m.Inner]("x"))
+  }
+}

--- a/src/main/scala/gestalt/Toolbox.scala
+++ b/src/main/scala/gestalt/Toolbox.scala
@@ -250,23 +250,44 @@ trait StructToolbox extends Toolbox {
   }
 }
 
-/** TypeToolbox defines extractors for inspecting expression trees as well as check types of trees
+/** TypeToolbox defines extractors for inspecting expression trees as well as APIs for types
  */
 trait TypeToolbox extends Toolbox { t =>
-  type Tree <: { def tpe: Type }
   type Type
+  type Member
 
-  // type operations
-  implicit class TypeOps(val tp1: Type) {
-    def =:=(tp2: Type) = t.=:=(tp1, tp2)
-    def <:<(tp2: Type) = t.<:<(tp1, tp2)
-  }
   /** get the location where the def macro is used */
   def currentLocation: Location
 
+  /** are the two types equal? */
   def =:=(tp1: Type, tp2: Type): Boolean
+
+  /** is `tp1` a subtype of `tp2` */
   def <:<(tp1: Type, tp2: Type): Boolean
-  def typeOf(path: String): Type
+
+  /** returning a type referring to a type definition */
+  def typeRef(path: String): Type
+
+  /** returning a type referring to a value definition */
+  def termRef(path: String): Type
+
+  /** type associated with the tree */
+  def typeOf(tree: Tree): Type
+
+  /** does the type refer to a case class? */
+  def isCaseClass(tp: Type): Boolean
+
+  /** val fields of a case class Type -- only the ones declared in primary constructor */
+  def caseFields(tp: Type): Seq[Member]
+
+  /* field with the given name */
+  def field(tp: Type, name: String): Option[Member]
+
+  /** name of a member */
+  def name(mem: Member): String
+
+  /** type of a member with respect to a prefix */
+  def asSeenFrom(mem: Member, prefix: Type): Type
 
   val Ascribe: AscribeHelper
   trait AscribeHelper {


### PR DESCRIPTION
Fix #48: Implement first set of semantic APIs.

- The semantic APIs are _mostly_ driven by macro use cases
- The semantic APIs minimises assumptions on compiler internals
- Instead of the concept `Symbol`, we find `Member` is more understandable

```Scala
  /** are the two types equal? */
  def =:=(tp1: Type, tp2: Type): Boolean

  /** is `tp1` a subtype of `tp2` */
  def <:<(tp1: Type, tp2: Type): Boolean

  /** returning a type referring to a type definition */
  def typeRef(path: String): Type

  /** returning a type referring to a value definition */
  def termRef(path: String): Type

  /** type associated with the tree */
  def typeOf(tree: Tree): Type

  /** does the type refer to a case class? */
  def isCaseClass(tp: Type): Boolean

  /** val fields of a case class Type -- only the ones declared in primary constructor */
  def caseFields(tp: Type): Seq[Member]

  /* field with the given name */
  def field(tp: Type, name: String): Option[Member]

  /** name of a member */
  def name(mem: Member): String

  /** type of a member with respect to a prefix */
  def asSeenFrom(mem: Member, prefix: Type): Type
```