### PR TITLE
Refactor of toolbox

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,8 @@ lazy val dottyVersion = "0.2.2-SNAPSHOT"
 lazy val common = Seq(
   resolvers ++= Seq(
     Resolver.sonatypeRepo("snapshots"),
-    Resolver.sonatypeRepo("releases")
+    Resolver.sonatypeRepo("releases"),
+    Resolver.typesafeIvyRepo("releases")
   )
 )
 

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -23,8 +23,8 @@ object plusObject {
 
   def varargs(items: Int*): Int = meta {
     items match {
-      case toolbox.SeqLiteral(items: Seq[toolbox.Tree]) =>
-        items.reduceLeft((a, b) => q"$a + $b")
+      case toolbox.SeqLiteral(items: Seq[toolbox.TermTree]) =>
+        items.reduceLeft[toolbox.TermTree]((a, b) => q"$a + $b")
       case q"$items: $_" =>
         q"$items.reduce((a:Int,b:Int)=> a + b)"
     }
@@ -32,8 +32,8 @@ object plusObject {
 
   def deconstructApply(items: Any): Int = meta {
     items match {
-      case toolbox.Apply(prefix: toolbox.Tree, items: Seq[toolbox.Tree]) =>
-        items.reduceLeft((a, b) => q"$a + $b")
+      case toolbox.Apply(prefix: toolbox.Tree, items: Seq[toolbox.TermTree]) =>
+        items.reduceLeft[toolbox.TermTree]((a, b) => q"$a + $b")
       case _ =>
         toolbox.error("expected application of Ints",items)
         toolbox.Lit(null)

--- a/macros/src/test/scala/gestalt/macros/QuasiquoteTest.scala
+++ b/macros/src/test/scala/gestalt/macros/QuasiquoteTest.scala
@@ -1,5 +1,3 @@
-import scala.collection.immutable.Seq
-
 import dotty.tools._
 import dotc.core.Contexts._
 

--- a/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
+++ b/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
@@ -1,8 +1,3 @@
-import scala.collection.immutable.Seq
-
-import dotty.tools._
-import dotc.core.Contexts._
-
 import scala.gestalt._
 
 class TypeToolboxTest extends TestSuite {

--- a/src/main/scala/gestalt/Quote.scala
+++ b/src/main/scala/gestalt/Quote.scala
@@ -17,12 +17,10 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
   def enclosingTree: t.Tree
 
   // helpers
-  private implicit class TreeOps(val tree: t.Tree) {
-    def select(name: String): t.Tree = t.Select(tree, name)
+  private implicit class TreeOps(val tree: t.TermTree) {
+    def select(name: String): t.TermTree = t.Select(tree, name)
 
-    def appliedTo(args: t.Tree*): t.Tree = t.Apply(tree, args.toList)
-
-    def appliedToType(args: t.TypeTree*): t.Tree = t.ApplyType(tree, args.toList)
+    def appliedTo(args: t.TermTree*): t.TermTree = t.Apply(tree, args.toList)
   }
 
   // lifted trees
@@ -33,20 +31,18 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
   lazy val toolbox   = t.Ident(toolboxName)
   lazy val root      = t.Ident("_root_")
 
-  private def select(path: String, isTerm: Boolean = true): t.Tree = {
+  private def select(path: String): t.TermTree = {
     val parts = path.split('.')
 
-    val qual = parts.init.foldLeft[t.Tree](root) { (prefix, name) =>
+    parts.foldLeft[t.TermTree](root) { (prefix, name) =>
       prefix.select(name)
     }
-
-    if (isTerm) t.Select(qual, parts.last) else t.TypeSelect(qual, parts.last)
   }
 
-  private def selectToolbox(path: String): t.Tree = {
+  private def selectToolbox(path: String): t.TermTree = {
     val parts = path.split('.')
 
-    val qual = parts.init.foldLeft[t.Tree](toolbox) { (prefix, name) =>
+    val qual = parts.init.foldLeft[t.TermTree](toolbox) { (prefix, name) =>
       prefix.select(name)
     }
 
@@ -57,8 +53,8 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     * AnyTree = t.Tree | t.TypeTree
     * (trees: Seq[m.Tree[A]]) => (t.Tree[Seq[String]] | t.Tree[Seq[AnyTree[?]]])
     * }}}*/
-  def liftSeq(trees: Seq[m.Tree]): t.Tree =  {
-    def loop(trees: List[m.Tree], acc: Option[t.Tree], prefix: List[m.Tree]): t.Tree = trees match {
+  def liftSeq(trees: Seq[m.Tree]): t.TermTree =  {
+    def loop(trees: List[m.Tree], acc: Option[t.TermTree], prefix: List[m.Tree]): t.TermTree = trees match {
       case (quasi: Quasi) +: rest if quasi.rank == 1 =>
         if (acc.isEmpty) {
           if (prefix.isEmpty) loop(rest, Some(liftQuasi(quasi)), Nil)
@@ -92,7 +88,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
   /** {{{
     * (treess: Seq[Seq[m.Tree[A]]]) => t.Tree[Seq[Seq[t.Tree[A]]]]
     * }}}*/
-  def liftSeqSeq(treess: Seq[Seq[m.Tree]]): t.Tree = {
+  def liftSeqSeq(treess: Seq[Seq[m.Tree]]): t.TermTree = {
     val tripleDotQuasis = treess.flatten.collect{ case quasi: Quasi if quasi.rank == 2 => quasi }
     if (tripleDotQuasis.length == 0) {
       val args = treess.map(liftSeq)
@@ -111,7 +107,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
   }
 
   /** (trees: Option[m.Tree[A]]) => t.Tree[Option[t.Tree[A]]] */
-  def liftOpt(treeOpt: Option[m.Tree]): t.Tree = treeOpt match {
+  def liftOpt(treeOpt: Option[m.Tree]): t.TermTree = treeOpt match {
     case Some(quasi: Quasi) =>
       liftQuasi(quasi, optional = true)
     case Some(tree) =>
@@ -121,7 +117,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
   }
 
   /**{{{(treesOpt: Option[Seq[m.Tree[A]]]) => t.Tree[Seq[t.Tree[A]}}} */
-  def liftOptSeq(treesOpt: Option[Seq[m.Tree]]): t.Tree = treesOpt match {
+  def liftOptSeq(treesOpt: Option[Seq[m.Tree]]): t.TermTree = treesOpt match {
     case Some(Seq(quasi: Quasi)) if quasi.rank > 0 && !isTerm =>
       liftQuasi(quasi)
     case Some(trees) =>
@@ -131,12 +127,12 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
   }
 
   /** {{{(tree: Quasi, Int, Boolean) => ( t.Tree[Any]| t.Tree[t.Tree[?]])}}} */
-  def liftQuasi(quasi: Quasi, expectedRank: Int = 0, optional: Boolean = false): t.Tree = {
+  def liftQuasi(quasi: Quasi, expectedRank: Int = 0, optional: Boolean = false): t.TermTree = {
     if (quasi.rank > 0) return liftQuasi(quasi.tree.asInstanceOf[Quasi], quasi.rank, optional)
 
     def arg(i: Int) =
-      if (!isTerm && optional) scalaSome.appliedTo(args(i))
-      else args(i)
+      if (!isTerm && optional) scalaSome.appliedTo(args(i).asInstanceOf[t.TermTree])
+      else args(i).asInstanceOf[t.TermTree]
 
     quasi.tree match {
       case m.Term.Name(Hole(i)) => arg(i)
@@ -146,8 +142,8 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
 
   /** Lift initcall : {{{qual.T[A, B](x, y)(z)}}}
     * {{{(tree: m.Tree[A]) => t.Tree[t.Tree[A]]}}} */
-  def liftInitCall(tree: m.Tree): t.Tree = {
-    def extractFun(tree: m.Tree): (t.Tree, t.Tree, t.Tree) = tree match {
+  def liftInitCall(tree: m.Tree): t.TermTree = {
+    def extractFun(tree: m.Tree): (t.TermTree, t.TermTree, t.TermTree) = tree match {
       case m.Type.Apply(m.Ctor.Ref.Select(qual, m.Ctor.Ref.Name(name)), targs) =>
         (scalaSome.appliedTo(lift(qual)), t.Lit(name), liftSeq(targs))
       case m.Type.Apply(m.Ctor.Ref.Name(name), targs) =>
@@ -156,7 +152,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
         (scalaNone, t.Lit(name), liftSeq(Nil))
     }
 
-    def initCall(ctor: m.Tree, argss: Seq[Seq[m.Tree]]): t.Tree = {
+    def initCall(ctor: m.Tree, argss: Seq[Seq[m.Tree]]): t.TermTree = {
       val (qualOpt, name, targs) = extractFun(ctor)
       selectToolbox("InitCall").appliedTo(qualOpt, name, targs, liftSeqSeq(argss))
     }
@@ -170,7 +166,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
   }
 
   /** {{{(trees: Seq[t.Tree[t.Tree[A]]]) => t.Tree[Seq[t.Tree[A]]]}}} */
-  def liftSeqTrees(trees: Seq[t.Tree]): t.Tree = trees match {
+  def liftSeqTrees(trees: Seq[t.TermTree]): t.TermTree = trees match {
     case head :: rest => t.Infix(head, "::", liftSeqTrees(rest))
     case _ => scalaNil
   }
@@ -186,7 +182,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     *
     * @param name "ValDecl", "VarDecl", "ValDef" or "VarDef"
     * */
-  def liftValDef(mods: t.Tree, pats: Seq[m.Pat], tpe: t.Tree, rhs: t.Tree, name: String): t.Tree = {
+  def liftValDef(mods: t.TermTree, pats: Seq[m.Pat], tpe: t.TermTree, rhs: t.TermTree, name: String): t.TermTree = {
     if (pats.size == 1) {
       // AnyTree = t.Tree | t.TypeTree
       //left: t.Tree[AnyTree[?]] | t.Tree[String]
@@ -215,7 +211,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
 
   /** Lift self annotation in class definition
     * {{{(tree: m.Tree[A]) => t.Tree[Option[t.Tree[A]]]}}} */
-  def liftSelf(tree: m.Tree): t.Tree = tree match {
+  def liftSelf(tree: m.Tree): t.TermTree = tree match {
     case m.Term.Param(_, m.Name.Anonymous(), _, _) =>
       scalaNone
     case m.Term.Param(_, m.Term.Name(name), Some(tp), _) =>
@@ -226,13 +222,13 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
 
   /** lift name to either Lit or Quasi
     * {{{(name: m.Name) => t.Tree[String]}} */
-  def liftName(name: m.Name): t.Tree = name match {
+  def liftName(name: m.Name): t.TermTree = name match {
     case quasi: Quasi => liftQuasi(quasi)
     case _ => t.Lit(name.value)
   }
 
   /** lift modifiers */
-  def liftMods(mods: Seq[m.Tree]): t.Tree = {
+  def liftMods(mods: Seq[m.Tree]): t.TermTree = {
     mods match {
       case Seq(quasi: Quasi) => return liftQuasi(quasi)
       case _ =>
@@ -242,7 +238,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
         }
     }
 
-    val zero: t.Tree = selectToolbox("emptyMods")
+    val zero: t.TermTree = selectToolbox("emptyMods")
 
     mods.foldLeft(zero) { (acc, mod) =>
       mod match {
@@ -281,9 +277,9 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
         case m.Mod.Lazy() =>
           t.Select(acc, "setLazy")
         case m.Mod.ValParam() =>
-          acc
+          t.Select(acc, "setValParam")
         case m.Mod.VarParam() =>
-          t.Select(acc, "setMutable")
+          t.Select(acc, "setVarParam")
         case m.Mod.Inline() =>
           t.Select(acc, "setInline")
       }
@@ -294,7 +290,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     * AnyTree = t.Tree | t.TypeTree
     * (tree: m.Tree[A]) => t.Tree[AnyTree[A]]
     * }}} */
-  def lift(tree: m.Tree): t.Tree = tree match {
+  def lift(tree: m.Tree): t.TermTree = tree match {
     case quasi: Quasi  =>
       liftQuasi(quasi)
 
@@ -459,7 +455,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     case m.Pat.Bind(m.Pat.Var.Term(name), expr) =>
       selectToolbox("Bind").appliedTo(t.Lit(name), lift(expr))
     case m.Pat.Alternative(lhs, rhs) =>
-      selectToolbox("Alternative").appliedTo(lift(lhs), lift(rhs))
+      selectToolbox("Alternative").appliedTo(scalaList.appliedTo(lift(lhs), lift(rhs)))
     case m.Pat.Tuple(args) =>
       selectToolbox("Tuple").appliedTo(liftSeq(args))
     case m.Pat.Extract(ref, targs, args) =>
@@ -529,21 +525,31 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     case m.Defn.Type(mods, name, tparams, body) =>
       selectToolbox("TypeAlias").appliedTo(liftMods(mods), liftName(name), liftSeq(tparams), lift(body))
     case m.Defn.Class(mods, name, tparams, ctor, m.Template(_, parents, self, stats)) =>
+      val (cmods, paramss) = ctor match {
+        case m.Ctor.Primary(mods, name, paramss) =>
+          (mods, paramss)
+      }
       selectToolbox("Class").appliedTo(
         liftMods(mods),
         liftName(name),
         liftSeq(tparams),
-        scalaSome.appliedTo(lift(ctor)),
+        liftMods(cmods),
+        liftSeqSeq(paramss),
         liftSeqTrees(parents.map(liftInitCall)),
         liftSelf(self),
         liftOptSeq(stats)
       )
     case m.Defn.Trait(mods, name, tparams, ctor, m.Template(_, parents, self, stats)) =>
+       val (cmods, paramss) = ctor match {
+        case m.Ctor.Primary(mods, name, paramss) =>
+          (mods, paramss)
+      }
       selectToolbox("Trait").appliedTo(
         liftMods(mods),
         liftName(name),
         liftSeq(tparams),
-        scalaSome.appliedTo(lift(ctor)),
+        liftMods(cmods),
+        liftSeqSeq(paramss),
         liftSeqTrees(parents.map(liftInitCall)),
         liftSelf(self),
         liftOptSeq(stats)
@@ -560,8 +566,6 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     // case m.Pkg(ref, stats) =>
     // case m.Pkg.Object(mods, name, templ) =>
 
-    case m.Ctor.Primary(mods, name, paramss) =>
-      selectToolbox("PrimaryCtor").appliedTo(liftMods(mods), liftSeqSeq(paramss))
     case m.Ctor.Secondary(mods, name, paramss, body) =>
       selectToolbox("SecondaryCtor").appliedTo(liftMods(mods), liftSeqSeq(paramss), lift(body))
     // case m.Ctor.Ref.Name(v) =>                       // handled by liftInitCall


### PR DESCRIPTION
Refactoring of toolbox:

- define more abstract type members for safety by construction
- define more extractors for expressions
- define representors for definition trees -- which is recommended over extractors
- merge `ValDef` with `VarDef` and add `Mutable` flag
- remove `PrimaryCtor`
- add flags `ValParam` and `VarParam` as in scala.meta