### PR TITLE
refactor to use extension methods on abstract type

### DIFF
--- a/src/main/scala/gestalt/Quote.scala
+++ b/src/main/scala/gestalt/Quote.scala
@@ -378,9 +378,9 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     case m.Term.Do(body, expr) =>
       selectToolbox("DoWhile").appliedTo(lift(body), lift(expr))
     case m.Term.For(enums, body) =>
-      selectToolbox("For").appliedTo(liftSeq(enums), lift(body))
+      selectToolbox("For.ForDo").appliedTo(liftSeq(enums), lift(body))
     case m.Term.ForYield(enums, body) =>
-      selectToolbox("For").appliedTo(liftSeq(enums), selectToolbox("Yield").appliedTo(lift(body)))
+      selectToolbox("For.ForYield").appliedTo(liftSeq(enums), lift(body))
     case m.Term.New(m.Template(Nil, Seq(mctor), m.Term.Param(Nil, m.Name.Anonymous(), None, None), None)) =>
       selectToolbox("New").appliedTo(liftInitCall(mctor))
     case m.Term.New(m.Template(_, parents, self, stats)) =>
@@ -577,24 +577,24 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
 
 
     case m.Enumerator.Generator(pat, rhs) =>
-      selectToolbox("GenFrom").appliedTo(lift(pat), lift(rhs))
+      selectToolbox("For.GenFrom").appliedTo(lift(pat), lift(rhs))
     case m.Enumerator.Val(pat, rhs) =>
-      selectToolbox("GenAlias").appliedTo(lift(pat), lift(rhs))
+      selectToolbox("For.GenAlias").appliedTo(lift(pat), lift(rhs))
     case m.Enumerator.Guard(cond) =>
-      selectToolbox("Guard").appliedTo(lift(cond))
+      selectToolbox("For.Guard").appliedTo(lift(cond))
 
     case m.Import(importers) =>
       selectToolbox("Import").appliedTo(liftSeq(importers))
     case m.Importer(ref, importees) =>
-      selectToolbox("ImportItem").appliedTo(lift(ref), liftSeq(importees))
+      selectToolbox("Import.Item").appliedTo(lift(ref), liftSeq(importees))
     case m.Importee.Wildcard() =>
-      selectToolbox("ImportName").appliedTo(t.Lit("_"))
+      selectToolbox("Import.Name").appliedTo(t.Lit("_"))
     case m.Importee.Name(m.Name.Indeterminate(name)) =>
-      selectToolbox("ImportName").appliedTo(t.Lit(name))
+      selectToolbox("Import.Name").appliedTo(t.Lit(name))
     case m.Importee.Rename(m.Name.Indeterminate(name), m.Name.Indeterminate(rename)) =>
-      selectToolbox("ImportRename").appliedTo(t.Lit(name), t.Lit(rename))
+      selectToolbox("Import.Rename").appliedTo(t.Lit(name), t.Lit(rename))
     case m.Importee.Unimport(m.Name.Indeterminate(name)) =>
-      selectToolbox("ImportHide").appliedTo(t.Lit(name))
+      selectToolbox("Import.Hide").appliedTo(t.Lit(name))
 
     case m.Case(pat, cond, body) =>
       selectToolbox("Case").appliedTo(lift(pat), liftOpt(cond), lift(body))

--- a/src/main/scala/gestalt/Toolbox.scala
+++ b/src/main/scala/gestalt/Toolbox.scala
@@ -9,11 +9,16 @@ trait Toolbox extends Trees with Symbols with Types {
   /** diagnostics - the implementation takes the position from the tree */
   def error(message: String, tree: Tree): Unit
 
+  /** stop macro transform - the implementation takes the position from the tree */
+  def abort(message: String, tree: Tree): Nothing
+
   /** generate fresh unique name */
   def fresh(prefix: String = "$local"): String
 }
 
-trait Trees {
+trait Trees extends Params with TypeParams with
+  ValDefs with ValDecls with DefDefs with DefDecls with
+  Classes with Traits with Objects {
   // safety by construction -- implementation can have TypeTree = Tree
   type Tree     >: Null <: AnyRef
   type TypeTree >: Null <: Tree
@@ -79,269 +84,325 @@ trait Trees {
   def emptyMods: Mods
 
   // definition trees
-  def Object(mods: Mods, name: String, parents: Seq[InitCall], selfOpt: Option[Self], stats: Seq[Tree]): Object
-  def Class(mods: Mods, name: String, tparams: Seq[TypeParam], ctorMods: Mods, paramss: Seq[Seq[Param]], parents: Seq[InitCall], self: Option[Self], stats: Seq[Tree]): Class
-  def AnonymClass(parents: Seq[InitCall], self: Option[Self], stats: Seq[Tree]): DefTree
-  def Trait(mods: Mods, name: String, tparams: Seq[TypeParam], ctorMods: Mods, paramss: Seq[Seq[Param]], parents: Seq[InitCall], self: Option[Self], stats: Seq[Tree]): Trait
-  def TypeDecl(mods: Mods, name: String, tparams: Seq[TypeParam], tbounds: Option[TypeTree]): DefTree
-  def TypeAlias(mods: Mods, name: String, tparams: Seq[TypeParam], rhs: TypeTree): DefTree
-  def DefDef(mods: Mods, name: String, tparams: Seq[TypeParam], paramss: Seq[Seq[Param]], tpe: Option[TypeTree], rhs: Tree): DefDef
-  def DefDecl(mods: Mods, name: String, tparams: Seq[TypeParam], paramss: Seq[Seq[Param]], tpe: TypeTree): DefDecl
-  def ValDef(mods: Mods, name: String, tpe: Option[TypeTree], rhs: Tree): ValDef
-  def PatDef(mods: Mods, lhs: TermTree, tpe: Option[TypeTree], rhs: Tree): DefTree
-  def SeqDef(mods: Mods, pats: Seq[TermTree], tpe: Option[TypeTree], rhs: Tree): DefTree
-  def ValDecl(mods: Mods, name: String, tpe: TypeTree): ValDecl
-  def SeqDecl(mods: Mods, vals: Seq[String], tpe: TypeTree): DefTree
-  def Param(mods: Mods, name: String, tpe: Option[TypeTree], default: Option[Tree]): Param
-  def TypeParam(mods: Mods, name: String, tparams: Seq[TypeParam], tbounds: Option[TypeTree], cbounds: Seq[TypeTree]): TypeParam
+  val AnonymClass: AnonymClassImpl
+  trait AnonymClassImpl {
+    def apply(parents: Seq[InitCall], self: Option[Self], stats: Seq[Tree]): DefTree
+  }
+
+  val TypeDecl: TypeDeclImpl
+  trait TypeDeclImpl {
+    def apply(mods: Mods, name: String, tparams: Seq[TypeParam], tbounds: Option[TypeTree]): DefTree
+  }
+
+  val TypeAlias: TypeAliasImpl
+  trait TypeAliasImpl {
+    def apply(mods: Mods, name: String, tparams: Seq[TypeParam], rhs: TypeTree): DefTree
+  }
+
+  val PatDef: PatDefImpl
+  trait PatDefImpl {
+    def apply(mods: Mods, lhs: TermTree, tpe: Option[TypeTree], rhs: Tree): DefTree
+  }
+
+  val SeqDef: SeqDefImpl
+  trait SeqDefImpl {
+    def apply(mods: Mods, pats: Seq[TermTree], tpe: Option[TypeTree], rhs: Tree): DefTree
+  }
+
+  val SeqDecl: SeqDeclImpl
+  trait SeqDeclImpl {
+    def apply(mods: Mods, vals: Seq[String], tpe: TypeTree): DefTree
+  }
+
   // extends qual.T[A, B](x, y)(z)
-  def InitCall(qual: Option[Tree], name: String, targs: Seq[TypeTree], argss: Seq[Seq[TermTree]]): InitCall
-  def SecondaryCtor(mods: Mods, paramss: Seq[Seq[Param]], rhs: TermTree): Tree
-  def Self(name: String, tpe: TypeTree): Self
-  def Self(name: String): Self
+  val InitCall: InitCallImpl
+  trait InitCallImpl {
+    def apply(qual: Option[Tree], name: String, targs: Seq[TypeTree], argss: Seq[Seq[TermTree]]): InitCall
+  }
+
+  val SecondaryCtor: SecondaryCtorImpl
+  trait SecondaryCtorImpl {
+    def apply(mods: Mods, paramss: Seq[Seq[Param]], rhs: TermTree): Tree
+  }
+
+  val Self: SelfImpl
+  trait SelfImpl {
+    def apply(name: String, tpe: TypeTree): Self
+    def apply(name: String): Self
+  }
 
   // type trees
-  def TypeIdent(name: String): TypeTree
-  def TypeSelect(qual: Tree, name: String): TypeTree
-  def TypeSingleton(ref: Tree): TypeTree
-  def TypeApply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree
-  def TypeApplyInfix(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree
-  def TypeFunction(params: Seq[TypeTree], res: TypeTree): TypeTree
-  def TypeTuple(args: Seq[TypeTree]): TypeTree
-  def TypeAnd(lhs: TypeTree, rhs: TypeTree): TypeTree
-  def TypeOr(lhs: TypeTree, rhs: TypeTree): TypeTree
-  def TypeRefine(tpe : Option[TypeTree], stats: Seq[Tree]): TypeTree
-  def TypeBounds(lo: Option[TypeTree], hi: Option[TypeTree]): TypeTree
-  def TypeRepeated(tpe: TypeTree): TypeTree
-  def TypeByName(tpe: TypeTree): TypeTree
-  def TypeAnnotated(tpe: TypeTree, annots: Seq[Tree]): TypeTree
+  val TypeIdent: TypeIdentImpl
+  trait TypeIdentImpl {
+    def apply(name: String): TypeTree
+  }
+
+  val TypeSelect: TypeSelectImpl
+  trait TypeSelectImpl {
+    def apply(qual: Tree, name: String): TypeTree
+  }
+
+  val TypeSingleton: TypeSingletonImpl
+  trait TypeSingletonImpl {
+    def apply(ref: Tree): TypeTree
+  }
+
+  val TypeApply: TypeApplyImpl
+  trait TypeApplyImpl {
+    def apply(tpe: TypeTree, args: Seq[TypeTree]): TypeTree
+  }
+
+  val TypeApplyInfix: TypeApplyInfixImpl
+  trait TypeApplyInfixImpl {
+    def apply(lhs: TypeTree, op: String, rhs: TypeTree): TypeTree
+  }
+
+  val TypeFunction: TypeFunctionImpl
+  trait TypeFunctionImpl {
+    def apply(params: Seq[TypeTree], res: TypeTree): TypeTree
+  }
+
+  val TypeTuple: TypeTupleImpl
+  trait TypeTupleImpl {
+    def apply(args: Seq[TypeTree]): TypeTree
+  }
+
+  val TypeAnd: TypeAndImpl
+  trait TypeAndImpl {
+    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree
+  }
+
+  val TypeOr: TypeOrImpl
+  trait TypeOrImpl {
+    def apply(lhs: TypeTree, rhs: TypeTree): TypeTree
+  }
+
+  val TypeRefine: TypeRefineImpl
+  trait TypeRefineImpl {
+    def apply(tpe: Option[TypeTree], stats: Seq[Tree]): TypeTree
+  }
+
+  val TypeBounds: TypeBoundsImpl
+  trait TypeBoundsImpl {
+    def apply(lo: Option[TypeTree], hi: Option[TypeTree]): TypeTree
+  }
+
+  val TypeRepeated: TypeRepeatedImpl
+  trait TypeRepeatedImpl {
+    def apply(tpe: TypeTree): TypeTree
+  }
+
+  val TypeByName: TypeByNameImpl
+  trait TypeByNameImpl {
+    def apply(tpe: TypeTree): TypeTree
+  }
+
+  val TypeAnnotated: TypeAnnotatedImpl
+  trait TypeAnnotatedImpl {
+    def apply(tpe: TypeTree, annots: Seq[Tree]): TypeTree
+  }
 
   // terms
-  def Lit(value: Any): TermTree
-  def Ident(name: String): TermTree
-  def Select(qual: TermTree, name: String): TermTree
-  def This(qual: String): TermTree
-  def Super(thisp: String, superp: String): TermTree
-  def Interpolate(prefix: String, parts: Seq[String], args: Seq[TermTree]): TermTree
-  def Apply(fun: TermTree, args: Seq[TermTree]): TermTree
-  def ApplyType(fun: TermTree, args: Seq[TypeTree]): TermTree
   // a + (b, c)  =>  Infix(a, +, Tuple(b, c))
-  def Infix(lhs: TermTree, op: String, rhs: TermTree): TermTree
-  def Prefix(op: String, od: TermTree): TermTree
-  def Postfix(od: TermTree, op: String): TermTree
-  def Assign(lhs: TermTree, rhs: TermTree): TermTree
-  def Return(expr: TermTree): TermTree
-  def Return: TermTree
-  def Throw(expr: TermTree): TermTree
-  def Ascribe(expr: TermTree, tpe: TypeTree): TermTree
-  def Annotated(expr: TermTree, annots: Seq[Tree]): TermTree
-  def Tuple(args: Seq[TermTree]): TermTree
-  def Block(stats: Seq[Tree]): TermTree
-  def If(cond: TermTree, thenp: TermTree, elsep: Option[TermTree]): TermTree
-  def Match(expr: TermTree, cases: Seq[Tree]): TermTree
-  def Case(pat: TermTree, cond: Option[TermTree], body: TermTree): Tree
-  def Try(expr: Tree, cases: Seq[Tree], finallyp: Option[TermTree]): TermTree
-  def Try(expr: TermTree, handler: Tree, finallyp: Option[TermTree]): Tree
-  def Function(params: Seq[Param], body: TermTree): TermTree
-  def PartialFunction(cases: Seq[Tree]): TermTree
-  def While(expr: TermTree, body: TermTree): TermTree
-  def DoWhile(body: TermTree, expr: TermTree): TermTree
-  def For(enums: Seq[Tree], body: TermTree): TermTree
-  def ForYield(enums: Seq[Tree], body: TermTree): TermTree
-  def GenFrom(pat: TermTree, rhs: TermTree): Tree
-  def GenAlias(pat: TermTree, rhs: TermTree): Tree
-  def Guard(cond: TermTree): Tree
-  // can be InitCall or AnonymClass
-  def New(tpe: Tree): TermTree
-  def Named(name: String, expr: Tree): TermTree
-  def Repeated(expr: Tree): TermTree
-
-  // patterns
-  def Bind(name: String, expr: TermTree): TermTree
-  def Alternative(trees: Seq[TermTree]): TermTree
-
-  // importees
-  def Import(items: Seq[Tree]): Tree
-  def ImportItem(prefix: Tree, importees: Seq[Tree]): Tree
-  def ImportName(name: String): Tree
-  def ImportRename(from: String, to: String): Tree
-  def ImportHide(name: String): Tree
-
-  // extractors
-  val Lit: LitHelper
-  trait LitHelper {
-    def unapply(tree: Tree): Option[Any]
+  val Infix: InfixImpl
+  trait InfixImpl {
+    def apply(lhs: TermTree, op: String, rhs: TermTree): TermTree
   }
 
-  val Apply: ApplyHelper
-  trait ApplyHelper {
-    def unapply(tree: Tree): Option[(TermTree, Seq[TermTree])]
+  val Prefix: PrefixImpl
+  trait PrefixImpl {
+    def apply(op: String, od: TermTree): TermTree
   }
 
-  val ApplyType: ApplyTypeHelper
-  trait ApplyTypeHelper {
-    def unapply(tree: Tree): Option[(TermTree, Seq[TypeTree])]
+  val Postfix: PostfixImpl
+  trait PostfixImpl {
+    def apply(od: TermTree, op: String): TermTree
   }
 
-  val Ident: IdentHelper
-  trait IdentHelper {
-    def unapply(tree: Tree): Option[String]
+  val Throw: ThrowImpl
+  trait ThrowImpl {
+    def apply(expr: TermTree): TermTree
   }
 
-  val This: ThisHelper
-  trait ThisHelper {
-    def unapply(tree: Tree): Option[String]
-  }
-
-  val Select: SelectHelper
-  trait SelectHelper {
-    def unapply(tree: Tree): Option[(TermTree, String)]
-  }
-
-  val Ascribe: AscribeHelper
-  trait AscribeHelper {
-    def unapply(tree: Tree): Option[(TermTree, TypeTree)]
-  }
-
-  val Assign: AssignHelper
-  trait AssignHelper {
-    def unapply(tree: Tree): Option[(TermTree, TermTree)]
-  }
-
-  val Annotated: AnnotatedHelper
-  trait AnnotatedHelper {
+  val Annotated: AnnotatedImpl
+  trait AnnotatedImpl {
+    def apply(expr: TermTree, annots: Seq[Tree]): TermTree
     def unapply(tree: Tree): Option[(TermTree, Seq[Tree])]
   }
 
-  val Block: BlockHelper
-  trait BlockHelper {
+  val If: IfImpl
+  trait IfImpl {
+    def apply(cond: TermTree, thenp: TermTree, elsep: Option[TermTree]): TermTree
+    def unapply(tree: Tree): Option[(TermTree, TermTree, Option[TermTree])]
+  }
+
+  val Try: TryImpl
+  trait TryImpl {
+    def apply(expr: Tree, cases: Seq[Tree], finallyp: Option[TermTree]): TermTree
+    def apply(expr: TermTree, handler: Tree, finallyp: Option[TermTree]): TermTree
+  }
+
+  val Function: FunctionImpl
+  trait FunctionImpl {
+    def apply(params: Seq[Param], body: TermTree): TermTree
+  }
+
+  val While: WhileImpl
+  trait WhileImpl {
+    def apply(expr: TermTree, body: TermTree): TermTree
+  }
+
+  val DoWhile: DoWhileImpl
+  trait DoWhileImpl {
+    def apply(body: TermTree, expr: TermTree): TermTree
+  }
+
+  val For: ForImpl
+  trait ForImpl {
+    def ForDo(enums: Seq[Tree], body: TermTree): TermTree
+    def ForYield(enums: Seq[Tree], body: TermTree): TermTree
+    def GenFrom(pat: TermTree, rhs: TermTree): Tree
+    def GenAlias(pat: TermTree, rhs: TermTree): Tree
+    def Guard(cond: TermTree): Tree
+  }
+
+  val New: NewImpl
+  trait NewImpl {
+    // can be InitCall or AnonymClass
+    def apply(tpe: Tree): TermTree
+  }
+
+  val Named: NamedImpl
+  trait NamedImpl {
+    def apply(name: String, expr: Tree): TermTree
+  }
+
+  val Repeated: RepeatedImpl
+  trait RepeatedImpl {
+    def apply(expr: Tree): TermTree
+  }
+
+  // patterns
+  val Bind: BindImpl
+  trait BindImpl {
+    def apply(name: String, expr: TermTree): TermTree
+  }
+
+  val Alternative: AlternativeImpl
+  trait AlternativeImpl {
+    def apply(trees: Seq[TermTree]): TermTree
+  }
+
+  // importees
+  val Import: ImportImpl
+  trait ImportImpl {
+    def apply(items: Seq[Tree]): Tree
+    def Item(prefix: Tree, importees: Seq[Tree]): Tree
+    def Name(name: String): Tree
+    def Rename(from: String, to: String): Tree
+    def Hide(name: String): Tree
+  }
+
+  // extractors
+  val Lit: LitImpl
+  trait LitImpl {
+    def apply(value: Any): TermTree
+    def unapply(tree: Tree): Option[Any]
+  }
+
+  val Apply: ApplyImpl
+  trait ApplyImpl {
+    def apply(fun: TermTree, args: Seq[TermTree]): TermTree
+    def unapply(tree: Tree): Option[(TermTree, Seq[TermTree])]
+  }
+
+  val ApplyType: ApplyTypeImpl
+  trait ApplyTypeImpl {
+    def apply(fun: TermTree, args: Seq[TypeTree]): TermTree
+    def unapply(tree: Tree): Option[(TermTree, Seq[TypeTree])]
+  }
+
+  val Ident: IdentImpl
+  trait IdentImpl {
+    def apply(name: String): TermTree
+    def unapply(tree: Tree): Option[String]
+  }
+
+  val This: ThisImpl
+  trait ThisImpl {
+    def apply(qual: String): TermTree
+    def unapply(tree: Tree): Option[String]
+  }
+
+  val Super: SuperImpl
+  trait SuperImpl {
+    def apply(thisp: String, superp: String): TermTree
+  }
+
+  val Select: SelectImpl
+  trait SelectImpl {
+    def apply(qual: TermTree, name: String): TermTree
+    def unapply(tree: Tree): Option[(TermTree, String)]
+  }
+
+  val Ascribe: AscribeImpl
+  trait AscribeImpl {
+    def apply(expr: TermTree, tpe: TypeTree): TermTree
+    def unapply(tree: Tree): Option[(TermTree, TypeTree)]
+  }
+
+  val Assign: AssignImpl
+  trait AssignImpl {
+    def apply(lhs: TermTree, rhs: TermTree): TermTree
+    def unapply(tree: Tree): Option[(TermTree, TermTree)]
+  }
+
+
+  val Return: ReturnImpl
+  trait ReturnImpl {
+    def apply(expr: TermTree): TermTree
+    def apply: TermTree
+    def unapply(tree: Tree): Option[Option[TermTree]]
+  }
+
+  val Block: BlockImpl
+  trait BlockImpl {
+    def apply(stats: Seq[Tree]): TermTree
     def unapply(tree: Tree): Option[Seq[Tree]]
   }
 
-  val PartialFunction: PartialFunctionHelper
-  trait PartialFunctionHelper {
+  val PartialFunction: PartialFunctionImpl
+  trait PartialFunctionImpl {
+    def apply(cases: Seq[Tree]): TermTree
     def unapply(tree: Tree): Option[Seq[Tree]]
   }
 
-  val Tuple: TupleHelper
-  trait TupleHelper {
+  val Match: MatchImpl
+  trait MatchImpl {
+    def apply(expr: TermTree, cases: Seq[Tree]): TermTree
+    def unapply(tree: Tree): Option[(TermTree, Seq[Tree])]
+  }
+
+  val Case: CaseImpl
+  trait CaseImpl {
+    def apply(pat: TermTree, cond: Option[TermTree], body: TermTree): Tree
+    def unapply(tree: Tree): Option[(TermTree, Option[TermTree], TermTree)]
+  }
+
+  val Tuple: TupleImpl
+  trait TupleImpl {
+    def apply(args: Seq[TermTree]): TermTree
     def unapply(tree: Tree): Option[Seq[TermTree]]
   }
 
-  val SeqLiteral: SeqLiteralHelper
-  trait SeqLiteralHelper {
+  val Interpolate: InterpolateImpl
+  trait InterpolateImpl {
+    def apply(prefix: String, parts: Seq[String], args: Seq[TermTree]): TermTree
+  }
+
+  val SeqLiteral: SeqLiteralImpl
+  trait SeqLiteralImpl {
     def unapply(tree: Tree): Option[Seq[TermTree]]
-  }
-
-  val Object: ObjectHelper
-  trait ObjectHelper {
-    def unapply(tree: Tree): Option[(Mods, String, Seq[InitCall], Option[Self], Seq[Tree])]
-  }
-
-  val Class: ClassHelper
-  trait ClassHelper {
-    def unapply(tree: Tree): Option[(Mods, String, Seq[TypeParam], Mods, Seq[Seq[Param]], Seq[InitCall], Option[Self], Seq[Tree])]
-  }
-
-  val Trait: TraitHelper
-  trait TraitHelper {
-    def unapply(tree: Tree): Option[(Mods, String, Seq[TypeParam], Mods, Seq[Seq[Param]], Seq[InitCall], Option[Self], Seq[Tree])]
-  }
-
-  // accessors for definition trees
-  implicit def toParamRep(tree: Param): ParamRep
-  trait ParamRep {
-    def mods: Mods
-    def name: String
-    def tpt: Option[TypeTree]
-    def default: Option[Tree]
-    def copy(name: String = this.name, mods: Mods = this.mods,
-             tptOpt: Option[TypeTree] = this.tpt, defaultOpt: Option[Tree] = this.default): Param
-  }
-
-  implicit def toTypeParamRep(tree: TypeParam): TypeParamRep
-  trait TypeParamRep {
-    def mods: Mods
-    def name: String
-    def tparams: Seq[TypeParam]
-  }
-
-  implicit def toClassRep(tree: Class): ClassRep
-  trait ClassRep {
-    def mods: Mods
-    def ctorMods: Mods
-    def name: String
-    def tparams: Seq[TypeParam]
-    def paramss: Seq[Seq[Param]]
-    def self: Option[Self]
-    def stats: Seq[Tree]
-
-    def copy(mods: Mods = this.mods, paramss: Seq[Seq[Param]] = this.paramss, stats: Seq[Tree] = this.stats): Class
-  }
-
-  val ClassRep: ClassRepHelper
-  trait ClassRepHelper {
-    def unapply(tree: Tree): Option[ClassRep]
-  }
-
-  implicit def toValDefRep(tree: ValDef): ValDefRep
-  trait ValDefRep {
-    def mods: Mods
-    def name: String
-    def tpt: Option[TypeTree]
-    def rhs: Tree
-    def copy(name: String = this.name, mods: Mods = this.mods,
-             tptOpt: Option[TypeTree] = this.tpt, rhs: Tree = this.rhs): ValDef
-  }
-
-  val ValDefRep: ValDefRepHelper
-  trait ValDefRepHelper {
-    def unapply(tree: Tree): Option[ValDefRep]
-  }
-
-  implicit def toValDeclRep(tree: ValDecl): ValDeclRep
-  trait ValDeclRep {
-    def mods: Mods
-    def name: String
-    def tpt: TypeTree
-    def copy(name: String = this.name, mods: Mods = this.mods, tpt: TypeTree = this.tpt): ValDecl
-  }
-
-  val ValDeclRep: ValDeclRepHelper
-  trait ValDeclRepHelper {
-    def unapply(tree: Tree): Option[ValDeclRep]
-  }
-
-  implicit def toDefDefRep(tree: DefDef): DefDefRep
-  trait DefDefRep {
-    def mods: Mods
-    def tparams: Seq[TypeParam]
-    def paramss: Seq[Seq[Param]]
-    def name: String
-    def tpt: Option[TypeTree]
-    def rhs: Tree
-    def copy(name: String = this.name, mods: Mods = this.mods,
-             tptOpt: Option[TypeTree] = this.tpt, rhs: Tree = this.rhs): DefDef
-  }
-
-  val DefDefRep: DefDefRepHelper
-  trait DefDefRepHelper {
-    def unapply(tree: Tree): Option[DefDefRep]
-  }
-
-  implicit def toDefDeclRep(tree: DefDecl): DefDeclRep
-  trait DefDeclRep {
-    def mods: Mods
-    def tparams: Seq[TypeParam]
-    def paramss: Seq[Seq[Param]]
-    def name: String
-    def tpt: TypeTree
-    def copy(name: String = this.name, mods: Mods = this.mods, tpt: TypeTree = this.tpt): DefDecl
-  }
-
-  val DefDeclRep: DefDeclRepHelper
-  trait DefDeclRepHelper {
-    def unapply(tree: Tree): Option[DefDeclRep]
   }
 
   // helpers
@@ -361,6 +422,255 @@ trait Trees {
     }
   }
 
+  // traverser
+  def traverse(tre: Tree)(pf: PartialFunction[Tree, Unit]): Unit
+  def exists(tree: Tree)(pf: PartialFunction[Tree, Boolean]): Boolean
+  def transform(tree: Tree)(pf: PartialFunction[Tree, Tree]): Tree
+}
+
+trait ValDefs { this: Trees =>
+  implicit class ValDefOps(tree: ValDef) {
+    def mods: Mods = ValDef.mods(tree)
+    def name: String = ValDef.name(tree)
+    def tptOpt: Option[TypeTree] = ValDef.tptOpt(tree)
+    def rhs: TermTree = ValDef.rhs(tree)
+    def copy(rhs: TermTree = this.rhs): ValDef = ValDef.copyRhs(tree)(rhs)
+  }
+
+  val ValDef: ValDefImpl
+  trait ValDefImpl {
+    def apply(mods: Mods, name: String, tpe: Option[TypeTree], rhs: Tree): ValDef
+    def mods(tree: ValDef): Mods
+    def name(tree: ValDef): String
+    def rhs(tree: ValDef): TermTree
+    def tptOpt(tree: ValDef): Option[TypeTree]
+    def copyRhs(tree: ValDef)(rhs: TermTree): ValDef
+    def get(tree: Tree): Option[ValDef]
+    def unapply(tree: Tree): Option[(Mods, String, Option[TypeTree], TermTree)]
+  }
+
+  object OfValDef {
+    def unapply(tree: Tree): Option[ValDef] = ValDef.get(tree)
+  }
+}
+
+trait ValDecls { this: Trees =>
+ implicit class ValDeclOps(tree: ValDecl) {
+    def mods: Mods = ValDecl.mods(tree)
+    def name: String = ValDecl.name(tree)
+    def tpt: TypeTree = ValDecl.tpt(tree)
+  }
+
+  val ValDecl: ValDeclImpl
+  trait ValDeclImpl {
+    def apply(mods: Mods, name: String, tpe: TypeTree): ValDecl
+    def mods(tree: ValDecl): Mods
+    def name(tree: ValDecl): String
+    def tpt(tree: ValDecl): TypeTree
+    def get(tree: Tree): Option[ValDecl]
+    def unapply(tree: Tree): Option[(Mods, String, TypeTree)]
+  }
+
+  object OfValDecl {
+    def unapply(tree: Tree): Option[ValDecl] = ValDecl.get(tree)
+  }
+}
+
+trait DefDefs { this: Trees =>
+  implicit class DefDefOps(tree: DefDef) {
+    def mods: Mods = DefDef.mods(tree)
+    def tparams: Seq[TypeParam] = DefDef.tparams(tree)
+    def paramss: Seq[Seq[Param]] = DefDef.paramss(tree)
+    def name: String = DefDef.name(tree)
+    def tptOpt: Option[TypeTree] = DefDef.tptOpt(tree)
+    def rhs: Tree = DefDef.rhs(tree)
+    def copy(rhs: Tree = this.rhs): DefDef = DefDef.copyRhs(tree)(rhs)
+  }
+
+  val DefDef: DefDefImpl
+  trait DefDefImpl {
+    def apply(mods: Mods, name: String, tparams: Seq[TypeParam], paramss: Seq[Seq[Param]], tpe: Option[TypeTree], rhs: Tree): DefDef
+    def mods(tree: DefDef): Mods
+    def tparams(tree: DefDef): Seq[TypeParam]
+    def paramss(tree: DefDef): Seq[Seq[Param]]
+    def name(tree: DefDef): String
+    def tptOpt(tree: DefDef): Option[TypeTree]
+    def rhs(tree: DefDef): TermTree
+    def copyRhs(tree: DefDef)(rhs: Tree): DefDef
+    def get(tree: Tree): Option[DefDef]
+    def unapply(tree: Tree): Option[(Mods, String, Seq[TypeParam], Seq[Seq[Param]], Option[TypeTree], TermTree)]
+  }
+
+  object OfDefDef {
+    def unapply(tree: Tree): Option[DefDef] = DefDef.get(tree)
+  }
+}
+
+trait DefDecls { this: Trees =>
+  implicit class DefDeclOps(tree: DefDecl) {
+    def mods: Mods = DefDecl.mods(tree)
+    def tparams: Seq[TypeParam] = DefDecl.tparams(tree)
+    def paramss: Seq[Seq[Param]] = DefDecl.paramss(tree)
+    def name: String = DefDecl.name(tree)
+    def tpt: TypeTree = DefDecl.tpt(tree)
+  }
+
+  val DefDecl: DefDeclImpl
+  trait DefDeclImpl {
+    def apply(mods: Mods, name: String, tparams: Seq[TypeParam], paramss: Seq[Seq[Param]], tpe: TypeTree): DefDecl
+    def mods(tree: DefDecl): Mods
+    def tparams(tree: DefDecl): Seq[TypeParam]
+    def paramss(tree: DefDecl): Seq[Seq[Param]]
+    def name(tree: DefDecl): String
+    def tpt(tree: DefDecl): TypeTree
+    def get(tree: Tree): Option[DefDecl]
+    def unapply(tree: Tree): Option[(Mods, String, Seq[TypeParam], Seq[Seq[Param]], TypeTree)]
+  }
+
+  object OfDefDecl {
+    def unapply(tree: Tree): Option[DefDecl] = DefDecl.get(tree)
+  }
+}
+
+trait Params { this: Trees =>
+  implicit class ParamOps(tree: Param) {
+    def mods: Mods = Param.mods(tree)
+    def name: String = Param.name(tree)
+    def tptOpt: Option[TypeTree] = Param.tptOpt(tree)
+    def defaultOpt: Option[TermTree] = Param.defaultOpt(tree)
+    def copy(mods: Mods = this.mods): Param
+    = Param.copyMods(tree)(mods)
+  }
+
+  val Param: ParamImpl
+  trait ParamImpl {
+    def apply(mods: Mods, name: String, tpe: Option[TypeTree], default: Option[TermTree]): Param
+    def mods(tree: Param): Mods
+    def name(tree: Param): String
+    def tptOpt(tree: Param): Option[TypeTree]
+    def defaultOpt(tree: Param): Option[TermTree]
+    def copyMods(tree: Param)(mods: Mods): Param
+  }
+}
+
+trait TypeParams { this: Trees =>
+  implicit class TypeParamOps(tree: TypeParam) {
+    def mods: Mods = TypeParam.mods(tree)
+    def name: String = TypeParam.name(tree)
+    def tparams: Seq[TypeParam] = TypeParam.tparams(tree)
+  }
+
+  val TypeParam: TypeParamImpl
+  trait TypeParamImpl {
+    def apply(mods: Mods, name: String, tparams: Seq[TypeParam], tbounds: Option[TypeTree], cbounds: Seq[TypeTree]): TypeParam
+    def mods(tree: TypeParam): Mods
+    def name(tree: TypeParam): String
+    def tparams(tree: TypeParam): Seq[TypeParam]
+  }
+}
+
+trait Classes { this: Trees =>
+  implicit def ClassOps(tree: Class) {
+    def mods: Mods = Class.mods(tree)
+    def ctorMods: Mods = Class.ctorMods(tree)
+    def name: String = Class.name(tree)
+    def tparams: Seq[TypeParam] = Class.tparams(tree)
+    def paramss: Seq[Seq[Param]] = Class.paramss(tree)
+    def parents: Seq[InitCall] = Class.parents(tree)
+    def selfOpt: Option[Self] = Class.selfOpt(tree)
+    def stats: Seq[Tree] = Class.stats(tree)
+    def copy(mods: Mods = Class.mods(tree), paramss: Seq[Seq[Param]] = Class.paramss(tree), stats: Seq[Tree] = Class.stats(tree)): Class
+    = {
+      val tree1 = Class.copyMods(tree)(mods)
+      val tree2 = Class.copyParamss(tree1)(paramss)
+      Class.copyStats(tree2)(stats)
+    }
+  }
+
+  val Class: ClassImpl
+  trait ClassImpl {
+    def apply(mods: Mods, name: String, tparams: Seq[TypeParam], ctorMods: Mods, paramss: Seq[Seq[Param]], parents: Seq[InitCall], self: Option[Self], stats: Seq[Tree]): Class
+    def mods(tree: Class): Mods
+    def name(tree: Class): String
+    def ctorMods(tree: Class): Mods
+    def tparams(tree: Class): Seq[TypeParam]
+    def paramss(tree: Class): Seq[Seq[Param]]
+    def parents(tree: Class): Seq[InitCall]
+    def selfOpt(tree: Class): Option[Self]
+    def stats(tree: Class): Seq[Tree]
+    def copyMods(tree: Class)(mods: Mods): Class
+    def copyParamss(tree: Class)(paramss: Seq[Seq[Param]]): Class
+    def copyStats(tree: Class)(stats: Seq[Tree]): Class
+    def get(tree: Tree): Option[Class]
+    def unapply(tree: Tree): Option[(Mods, String, Seq[TypeParam], Mods, Seq[Seq[Param]], Seq[InitCall], Option[Self], Seq[Tree])]
+  }
+
+  object OfClass {
+    def unapply(tree: Tree): Option[Class] = Class.get(tree)
+  }
+}
+
+trait Traits { this: Trees =>
+  implicit def TraitOps(tree: Trait) {
+    def mods: Mods = Trait.mods(tree)
+    def name: String = Trait.name(tree)
+    def tparams: Seq[TypeParam] = Trait.tparams(tree)
+    def paramss: Seq[Seq[Param]] = Trait.paramss(tree)
+    def parents: Seq[InitCall] = Trait.parents(tree)
+    def selfOpt: Option[Self] = Trait.selfOpt(tree)
+    def stats: Seq[Tree] = Trait.stats(tree)
+    def copy(stats: Seq[Tree] = Trait.stats(tree)): Trait
+    = Trait.copyStats(tree)(stats)
+  }
+
+  val Trait: TraitImpl
+  trait TraitImpl {
+    def apply(mods: Mods, name: String, tparams: Seq[TypeParam], ctorMods: Mods, paramss: Seq[Seq[Param]], parents: Seq[InitCall], self: Option[Self], stats: Seq[Tree]): Trait
+    def mods(tree: Trait): Mods
+    def name(tree: Trait): String
+    def tparams(tree: Trait): Seq[TypeParam]
+    def paramss(tree: Trait): Seq[Seq[Param]]
+    def parents(tree: Trait): Seq[InitCall]
+    def selfOpt(tree: Trait): Option[Self]
+    def stats(tree: Trait): Seq[Tree]
+    def copyStats(tree: Trait)(stats: Seq[Tree]): Trait
+    def get(tree: Tree): Option[Trait]
+    def unapply(tree: Tree): Option[(Mods, String, Seq[TypeParam], Mods, Seq[Seq[Param]], Seq[InitCall], Option[Self], Seq[Tree])]
+  }
+
+  object OfTrait {
+    def unapply(tree: Tree): Option[Trait] = Trait.get(tree)
+  }
+}
+
+trait Objects { this: Trees =>
+   implicit def ObjectOps(tree: Object) {
+    def mods: Mods = Object.mods(tree)
+    def name: String = Object.name(tree)
+    def parents: Seq[InitCall] = Object.parents(tree)
+    def selfOpt: Option[Self] = Object.selfOpt(tree)
+    def stats: Seq[Tree] = Object.stats(tree)
+    def copy(stats: Seq[Tree] = Object.stats(tree)): Object
+    = Object.copyStats(tree)(stats)
+  }
+
+  val Object: ObjectImpl
+  trait ObjectImpl {
+    def apply(mods: Mods, name: String, parents: Seq[InitCall], selfOpt: Option[Self], stats: Seq[Tree]): Object
+    def mods(tree: Object): Mods
+    def name(tree: Object): String
+    def parents(tree: Object): Seq[InitCall]
+    def selfOpt(tree: Object): Option[Self]
+    def stats(tree: Object): Seq[Tree]
+    // separate copy for better versioning compatibility
+    def copyStats(tree: Object)(stats: Seq[Tree]): Object
+    def get(tree: Tree): Option[Object]
+    def unapply(tree: Tree): Option[(Mods, String, Seq[InitCall], Option[Self], Seq[Tree])]
+  }
+
+  object OfObject {
+    def unapply(tree: Tree): Option[Object] = Object.get(tree)
+  }
 }
 
 trait Types { this: Toolbox =>
@@ -384,7 +694,7 @@ trait Types { this: Toolbox =>
   /** does the type refer to a case class? */
   def isCaseClass(tp: Type): Boolean
 
-  /** fields of a case class Type -- only the ones declared in primary constructor */
+  /** fields of a case class type -- only the ones declared in primary constructor */
   def caseFields(tp: Type): Seq[Symbol]
 
   /** field with the given name directly declared in the class */


### PR DESCRIPTION
refactor to use extension methods on abstract type.

This PR doesn't affect API, except `For` and `Import`, where it's grouped.