### PR TITLE
support multi-param blocks

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -151,3 +151,13 @@ object CaseInfo {
     }
   }
 }
+
+object MultiParamBlocks {
+  def f(a: Int)(b: Int): Int = meta {
+    q"$a + $b"
+  }
+
+  def g(a: Int)(b: Int)(implicit c: Int): Int = meta {
+    q"$a + $b - $c"
+  }
+}

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -183,4 +183,12 @@ class DefMacroTest extends TestSuite {
     // class Teacher(name: String, age: Int)
     // assert(fields[Teacher] == List())
   }
+
+  test("mutiple param blocks") {
+    import MultiParamBlocks._
+    assert(f(1)(2) == 3)
+
+    implicit val x: Int = 1
+    assert(g(1)(2) == 2)
+  }
 }

--- a/src/main/scala/gestalt/dotty/Expander.scala
+++ b/src/main/scala/gestalt/dotty/Expander.scala
@@ -98,7 +98,14 @@ object Expander {
       impl.setAccessible(true)
 
       val trees  = new Toolbox(tree.pos) :: prefix :: targs ++ argss.flatten
-      impl.invoke(null, trees: _*).asInstanceOf[untpd.Tree]
+      try {
+        impl.invoke(null, trees: _*).asInstanceOf[untpd.Tree]
+      }
+      catch {
+        case e: Exception =>
+          ctx.error("error occurred while expanding macro: \n" + e.getMessage, tree.pos)
+          untpd.Literal(Constant(null)).withPos(tree.pos)
+      }
     case _ =>
       ctx.warning(s"Unknown macro expansion: $tree")
       tree


### PR DESCRIPTION
The multi-param block support is fixed in https://github.com/liufengyun/dotty/commit/b2a85c4e4b350eae82d135fc62aae99684085b0c. The commit also refactor macro expansion to minimise changes to the compiler core.