### PR TITLE
Prefer denotations over symbols in the API

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -140,13 +140,14 @@ object Locations {
 
 object CaseInfo {
   def fields[T]: List[String] = meta {
-    val tp = toolbox.typeOf(T)
-    if (!toolbox.isCaseClass(tp)) {
+    import toolbox._
+    val tp = T.tpe
+    if (!tp.isCaseClass) {
       toolbox.error("Not a case class", T)
       q"scala.Nil"
     }
     else {
-      val fieldTrees = toolbox.caseFields(tp).map(m => toolbox.Lit(toolbox.name(m)))
+      val fieldTrees = tp.caseFields.map(m => toolbox.Lit(m.name))
       q"List(..$fieldTrees)"
     }
   }

--- a/macros/src/main/scala/gestalt/macros/TypeToolbox.scala
+++ b/macros/src/main/scala/gestalt/macros/TypeToolbox.scala
@@ -64,10 +64,7 @@ object TypeToolbox {
     import toolbox._
     val Lit(fd: String) = mem
     val expectedTp = Expected.tpe
-    println("field:" + Pre.tpe.fieldIn(fd))
     val fieldTp = Pre.tpe.fieldIn(fd).get.info
-    println("fieldTp: " + fieldTp)
-    println("expected: " + expectedTp)
     val res = fieldTp <:< expectedTp
     Lit(res)
   }

--- a/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
+++ b/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
@@ -63,7 +63,7 @@ class TypeToolboxTest extends TestSuite {
     case class M[T](x: T)
     val a = new M(4)
 
-    assert(asSeenFrom[a.type, Int]("x"))
+    assert(fieldType[a.type, Int]("x"))
 
 
     trait Base {
@@ -77,7 +77,7 @@ class TypeToolboxTest extends TestSuite {
     }
 
     val m = new Child
-    assert(asSeenFrom[m.type, m.Inner]("x"))
+    assert(fieldType[m.type, m.Inner]("x"))
 
     trait Box {
       type T
@@ -88,7 +88,7 @@ class TypeToolboxTest extends TestSuite {
       val x = 3
     }
     val box = new InBox
-    assert(asSeenFrom[box.type, Int]("x"))
+    assert(fieldType[box.type, Int]("x"))
   }
 
   test("fields") {
@@ -107,10 +107,8 @@ class TypeToolboxTest extends TestSuite {
     assert(fieldIn[Base]("x") == "x")
     assert(fieldIn[Derived]("x") == "")
     assert(fieldIn[Derived]("y") == "y")
-    assert(fieldsIn[Base].size == 1)
-    assert(fieldsIn[Base].head == "x")
-    assert(fieldsIn[Derived].size == 1)
-    assert(fieldsIn[Derived].head == "y")
+    assert(fieldsIn[Base] == List("x"))
+    assert(fieldsIn[Derived] == List("y"))
   }
 
   test("methods") {
@@ -130,8 +128,7 @@ class TypeToolboxTest extends TestSuite {
     assert(method[Base]("x") == Nil)
     assert(methodIn[Base]("f") == List("f"))
     assert(methodIn[Base]("x") == Nil)
-    assert(methodsIn[Base].size == 1)
-    assert(methodsIn[Base].head == "f")
+    assert(methodsIn[Base] == List("f"))
 
     assert(method[Derived]("f") == List("f"))
     assert(method[Derived]("g") == List("g"))

--- a/src/main/scala/gestalt/Denotations.scala
+++ b/src/main/scala/gestalt/Denotations.scala
@@ -1,0 +1,20 @@
+package scala.gestalt
+
+trait Denotations { self: Toolbox =>
+  type Denotation
+
+  implicit class DenotationOps(denot: Denotation) {
+    def name: String = Denotation.name(denot)
+    def info: Type = Denotation.info(denot)
+    def symbol: Symbol = Denotation.symbol(denot)
+  }
+
+  val Denotation: DenotationImpl
+  trait DenotationImpl {
+    def name(denot: Denotation): String
+
+    def info(denot: Denotation): Type
+
+    def symbol(denot: Denotation): Symbol
+  }
+}

--- a/src/main/scala/gestalt/Symbols.scala
+++ b/src/main/scala/gestalt/Symbols.scala
@@ -2,14 +2,18 @@ package scala.gestalt
 
 trait Symbols { this: Toolbox =>
   type Symbol
-  type MethodSymbol <: Symbol
 
-  /** name of a member */
-  def name(mem: Symbol): String
+  implicit class SymbolOps(sym: Symbol) {
+    def name: String = Symbol.name(sym)
+    def asSeenFrom(prefix: Type): Type = Symbol.asSeenFrom(sym, prefix)
+  }
 
-  /** type of a member with respect to a prefix */
-  def asSeenFrom(mem: Symbol, prefix: Type): Type
+  val Symbol: SymbolImpl
+  trait SymbolImpl {
+    /** name of a member */
+    def name(mem: Symbol): String
 
-  // def tparams(method: MethodSymbol): Seq[String]
-  // def paramss(method: MethodSymbol): Seq[Seq[(name, Symbol)]]
+    /** type of a member with respect to a prefix */
+    def asSeenFrom(mem: Symbol, prefix: Type): Type
+  }
 }

--- a/src/main/scala/gestalt/Toolbox.scala
+++ b/src/main/scala/gestalt/Toolbox.scala
@@ -2,7 +2,7 @@ package scala.gestalt
 
 case class Location(fileName: String, line: Int, column: Int)
 
-trait Toolbox extends Trees with Symbols with Types with TypeTags {
+trait Toolbox extends Trees with Types with Denotations with Symbols with TypeTags {
   /** get the location where the def macro is used */
   def currentLocation: Location
 

--- a/src/main/scala/gestalt/Types.scala
+++ b/src/main/scala/gestalt/Types.scala
@@ -1,51 +1,93 @@
 package scala.gestalt
 
-trait Types { this: Toolbox =>
+trait Types extends MethodTypes { self: Toolbox =>
   type Type
 
-  /** pretty print type */
-  def show(tp: Type): String
+  implicit class TypeOps(tp: Type) {
+    def =:=(tp2: Type) = Type.=:=(tp, tp2)
+    def <:<(tp2: Type) = Type.<:<(tp, tp2)
+    def isCaseClass = Type.isCaseClass(tp)
+    def caseFields: Seq[Denotation] = Type.caseFields(tp)
+    def fieldIn(name: String): Option[Denotation] = Type.fieldIn(tp, name)
+    def fieldsIn: Seq[Denotation] = Type.fieldsIn(tp)
+    def methodIn(name: String): Seq[Denotation] = Type.methodIn(tp, name)
+    def methodsIn: Seq[Denotation] = Type.methodsIn(tp)
+    def method(name: String): Seq[Denotation] = Type.method(tp, name)
+    def methods: Seq[Denotation] = Type.methods(tp)
+    def show: String = Type.show(tp)
+  }
 
-  /** are the two types equal? */
-  def =:=(tp1: Type, tp2: Type): Boolean
+  implicit class TreeTypeOps(tree: Tree) {
+    def tpe: Type = Type.typeOf(tree)
+  }
 
-  /** is `tp1` a subtype of `tp2` */
-  def <:<(tp1: Type, tp2: Type): Boolean
+  val Type: TypeImpl
+  trait TypeImpl {
+    /** pretty print type */
+    def show(tp: Type): String
 
-  /** returning a type referring to a type definition */
-  def typeRef(path: String): Type
+    /** are the two types equal? */
+    def =:=(tp1: Type, tp2: Type): Boolean
 
-  /** returning a type referring to a value definition */
-  def termRef(path: String): Type
+    /** is `tp1` a subtype of `tp2` */
+    def <:<(tp1: Type, tp2: Type): Boolean
 
-  /** type associated with the tree */
-  def typeOf(tree: Tree): Type
+    /** returning a type referring to a global type definition */
+    def typeRef(path: String): Type
 
-  /** does the type refer to a case class? */
-  def isCaseClass(tp: Type): Boolean
+    /** returning a type referring to a global value definition */
+    def termRef(path: String): Type
 
-  /** fields of a case class type -- only the ones declared in primary constructor */
-  def caseFields(tp: Type): Seq[Symbol]
+    /** type associated with the tree */
+    def typeOf(tree: Tree): Type
 
-  /** field with the given name directly declared in the class */
-  def fieldIn(tp: Type, name: String): Option[Symbol]
+    /** does the type refer to a case class? */
+    def isCaseClass(tp: Type): Boolean
 
-  /** fields directly declared in the class */
-  def fieldsIn(tp: Type): Seq[Symbol]
+    /** fields of a case class type -- only the ones declared in primary constructor */
+    def caseFields(tp: Type): Seq[Denotation]
 
-  /** get non-private named methods defined directly inside the class */
-  def methodIn(tp: Type, name: String): Seq[MethodSymbol]
+    /** field with the given name directly declared in the class */
+    def fieldIn(tp: Type, name: String): Option[Denotation]
 
-  /** get all non-private methods defined directly inside the class, exluding constructors */
-  def methodsIn(tp: Type): Seq[MethodSymbol]
+    /** fields directly declared in the class */
+    def fieldsIn(tp: Type): Seq[Denotation]
 
-  /** get named non-private methods declared or inherited */
-  def method(tp: Type, name: String): Seq[MethodSymbol]
+    /** get non-private named methods defined directly inside the class */
+    def methodIn(tp: Type, name: String): Seq[Denotation]
 
-  /** get all non-private methods declared or inherited */
-  def methods(tp: Type): Seq[MethodSymbol]
+    /** get all non-private methods defined directly inside the class, exluding constructors */
+    def methodsIn(tp: Type): Seq[Denotation]
 
-  /** get members directly declared or inherited that satisfy the predicate */
-  // def members(tp: Type, pred: Symbol => Boolean = s => true): Seq[Symbol]
+    /** get named non-private methods declared or inherited */
+    def method(tp: Type, name: String): Seq[Denotation]
+
+    /** get all non-private methods declared or inherited */
+    def methods(tp: Type): Seq[Denotation]
+  }
+
+
+  /*-------------------- type extractors ---------------------*/
+
+  val ByNameType: ByNameTypeImpl
+  trait ByNameTypeImpl {
+    def unapply(tp: Type): Option[Type]
+  }
+}
+
+trait MethodTypes { this: Types =>
+  type MethodType
+
+  implicit class MethodTypeOps(tp: MethodType) {
+    def paramInfos: Seq[Type] = MethodType.paramInfos(tp)
+    def instantiate(params: Seq[Type]): Type = MethodType.instantiate(tp)(params)
+  }
+
+  val MethodType: MethodTypeImpl
+  trait MethodTypeImpl {
+    def paramInfos(tp: MethodType): Seq[Type]
+    def instantiate(tp: MethodType)(params: Seq[Type]): Type
+    def unapply(tp: Type): Option[MethodType]
+  }
 }
 


### PR DESCRIPTION
I'm pretty receptive to the concept `Denotation`, I think it provides better experience to deal with path-dependent types.

This PR wraps type operations as extension methods.