### PR TITLE
Monadless test case

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -12,12 +12,13 @@ object plusObject {
     q"$a + $b"
   }
   def poly(a: Any, b: Int): Int = meta {
+    import toolbox._
     a match {
-      case toolbox.Lit(i:Int) => q"$a + $b"
-      case toolbox.Lit(s:String) => q"$a.toInt + $b"
+      case Lit(i:Int) => q"$a + $b"
+      case Lit(s:String) => q"$a.toInt + $b"
       case other =>
-        toolbox.error(s"expected String or Interger constants",a)
-        toolbox.Lit(null)
+        error(s"expected String or Interger constants", a.pos)
+        Lit(null)
     }
   }
 
@@ -31,12 +32,14 @@ object plusObject {
   }
 
   def deconstructApply(items: Any): Int = meta {
+    import toolbox._
+
     items match {
-      case toolbox.Apply(prefix: toolbox.Tree, items: Seq[toolbox.TermTree]) =>
-        items.reduceLeft[toolbox.TermTree]((a, b) => q"$a + $b")
+      case Apply(prefix: Tree, items: Seq[TermTree]) =>
+        items.reduceLeft[TermTree]((a, b) => q"$a + $b")
       case _ =>
-        toolbox.error("expected application of Ints",items)
-        toolbox.Lit(null)
+        error("expected application of Ints", items.pos)
+        Lit(null)
     }
   }
 }
@@ -143,7 +146,7 @@ object CaseInfo {
     import toolbox._
     val tp = T.tpe
     if (!tp.isCaseClass) {
-      toolbox.error("Not a case class", T)
+      error("Not a case class", T.pos)
       q"scala.Nil"
     }
     else {

--- a/macros/src/main/scala/gestalt/macros/Monadless.scala
+++ b/macros/src/main/scala/gestalt/macros/Monadless.scala
@@ -1,0 +1,323 @@
+import scala.gestalt._
+
+trait Monadless[Monad[_]] {
+
+  type M[T] = Monad[T]
+
+  /* "ghost" methods
+
+    def apply[T](v: => T): M[T]
+    def collect[T](list: List[M[T]]): M[List[T]]
+    def rescue[T](m: M[T])(pf: PartialFunction[Throwable, M[T]]): M[T]
+    def ensure[T](m: M[T])(f: => Unit): M[T]
+
+  */
+
+  def lift[T](body: T)(implicit m: toolbox.WeakTypeTag[Monad[_]]): Monad[T] = meta {
+    val tree = Transformer(toolbox)(this, body)
+    toolbox.traverse(tree) {
+      case tree @ q"$pack.unlift[$t]($v)" =>
+        toolbox.error("Unsupported unlift position", tree)
+    }
+    tree
+  }
+
+  def unlift[T](m: M[T]): T = throw new Exception("Unlift must be used within a `lift` body.")
+}
+
+object Monadless {
+  def apply[M[_]](): Monadless[M] = new Monadless[M] {}
+}
+
+
+
+object Transformer {
+
+  def apply(toolbox: Toolbox)(prefix: toolbox.TermTree, tree: toolbox.Tree)(implicit m: toolbox.WeakTypeTag[_]): toolbox.Tree = {
+    import toolbox._
+
+    def toParam(name: String) = Param(emptyMods, name, None, None)
+    def wrap(tree: Tree): Splice = TypedSplice(tree)
+
+    def validate(tree: Tree): Tree = {
+      traverse(tree) {
+        case t @ Match(_, cases) =>
+          cases.foreach {
+            case Case(_, Some(t @ Transform(_)), _) =>
+              abort("Unlift can't be used as a case guard.", t)
+            case Case(_, _, body) =>
+              validate(body)
+          }
+
+        case t @ Return(_) =>
+          abort("Lifted expression can't contain `return` statements.", t)
+
+        case t @ ValDef(mods, _, _, Transform(_)) if mods.isLazy =>
+          abort("Unlift can't be used as a lazy val initializer.", t)
+
+        case t @ ApplySeq(method, argss) if argss.size > 0 =>
+          var methodTp: MethodType = method.tpe.asInstanceOf[MethodType]
+          argss.map { args =>
+            val paramTypes = methodTp.paramInfos
+            paramTypes.zip(args).map {
+              case (ByNameType(_), Transform(_)) =>
+                abort("Unlift can't be used as by-name param.", t)
+              case other =>
+                ()
+            }
+            methodTp.instantiate(args.map(_.tpe)) match {
+              case tp: MethodType => methodTp = tp
+              case _ => methodTp = null   // last param block
+            }
+          }
+          argss.flatten.foreach(validate(_))
+
+        case t @ DefDef(mods, _, _, paramss, _, Transform(body)) =>
+          validate(body)
+      }
+      tree
+    }
+
+    object PureTree {
+      def unapply(tree: Tree): Option[Tree] =
+        exists(tree) {
+          case q"$pack.unlift[$t]($v)" => true
+        } match {
+          case true  => None
+          case false => Some(tree)
+        }
+    }
+
+    object TransformBlock {
+      def unapply(trees: List[Tree]): Option[TermTree] =
+        trees match {
+          case ValDef(mods, name, _, Transform(monad)) :: tail =>
+            Some(Nest(monad, name, Block(tail)))
+
+          case Transform(head) :: Nil =>
+            Some(head)
+
+          case Transform(monad) :: tail =>
+            Some(Nest(monad, "_", Block(tail)))
+
+          case head :: TransformBlock(Block(tail)) =>
+            Some(Block(head +: tail))
+
+          case other => None
+        }
+    }
+
+    object Nest {
+      def apply(monad: TermTree, name: String, body: TermTree): TermTree =
+        body match {
+          case Transform(body) =>
+            ??? // q"${Resolve.flatMap(monad, monad)}(${toParam(name)} => $body)"
+          case body            =>
+            ??? // q"${Resolve.map(monad, monad)}(${toParam(name)} => $body)"
+        }
+    }
+
+    object Transform {
+
+      def apply(tree: Tree): Tree =
+        unapply(tree).getOrElse(tree)
+
+      def unapply(tree: Tree): Option[TermTree] = tree match {
+        case PureTree(tree) => None
+
+        case Ascribe(tree, _) => unapply(tree)
+
+        case Block(trees) if trees.size > 1 => TransformBlock.unapply(trees.toList)
+
+        case If(Transform(monad), ifTrue, ifFalse) =>
+          val name = fresh()
+          val body = If(Ident(name), ifTrue, ifFalse)
+          Some(Nest(monad, name, body))
+
+        case If(cond, ifTrue, Some(ifFalse)) =>
+          (ifTrue, ifFalse) match {
+            case (Transform(ifTrue), Transform(ifFalse)) =>
+              Some(If(cond, ifTrue, Some(ifFalse)))
+            case (Transform(ifTrue), ifFalse) =>
+              val elsep = Apply(Resolve.apply(tree), List(ifFalse))
+              Some(If(cond, ifTrue, Some(elsep)))
+            case (ifTrue, Some(Transform(ifFalse))) =>
+              val ifp = Apply(Resolve.apply(tree), List(ifTrue))
+              Some(If(cond, ifp, Some(ifFalse)))
+            case (ifTrue, ifFalse) =>
+              None
+          }
+
+
+        case q"unlift[$t]($v)" => Some(v)
+        case q"$pack.unlift[$t]($v)" => Some(v)
+
+        case tree: Tree =>
+          val unlifts = collection.mutable.ListBuffer.empty[(TermTree, String, TypeTree)]
+          val newTree =
+            transform(tree) {
+              case q"unlift[$tp]($v)" =>
+                val name = fresh()
+                val splice = wrap(tp)
+                unlifts += ((v, name, splice))
+                Lit(name)
+
+              case q"$pack.unlift[$tp]($v)" =>
+                val name = fresh()
+                val splice = wrap(tp)
+                unlifts += ((v, name, splice))
+                Lit(name)
+            }
+
+          unlifts.toList match {
+            case List() => None
+            case List((tree, name, _)) =>
+              ??? // Some(q"${Resolve.map(tree, tree)}(${toParam(name)} => $newTree)")
+            case unlifts =>
+              val (trees, names, types) = unlifts.unzip3
+              val list = fresh("list")
+              val iterator = fresh("iterator")
+              val collect = q"${Resolve.collect(tree)}(scala.List(..${trees.toSeq}))"
+
+              val elements = unlifts.map {
+                case (tree, name, tpe) =>
+                  q"val $name = ${Ident(iterator)}.next().asInstanceOf[$tpe]"
+              }
+
+              Some(
+                q"""
+                    ${Resolve.map(tree, collect)} { ${toParam(list)} =>
+                      val $iterator = ${Ident(list)}.iterator
+                      ..$elements
+                      $newTree
+                    }
+                  """
+              )
+          }
+      }
+    }
+
+    object Resolve {
+
+      private val monadTypeName = m.tpe.show
+      private val sourceCompatibilityMessage =
+        s"""For instance, it's possible to add implicits or default parameters to the method
+           |without breaking source compatibility.
+           |Note: the methods defined by the `Monadless` instance have precedence over the ones
+           |defined by the monad instance and its companion object.
+        """.stripMargin
+
+      def apply(pos: Tree): TermTree =
+        companionMethod(pos, "apply").getOrElse {
+          val msg =
+            s"""Transformation requires the method `apply` to create a monad instance for a value.
+               |${companionMethodErrorMessage(s"def apply[T](v: => T): $monadTypeName[T]")}
+            """.stripMargin
+          abort(msg, pos)
+        }
+
+      def collect(pos: Tree): TermTree =
+        companionMethod(pos, "collect").getOrElse {
+          val msg =
+            s"""Transformation requires the method `collect` to transform List[M[T]] into M[List[T]]. The implementation
+               |is free to collect the results sequentially or in parallel.
+               |${companionMethodErrorMessage(s"def collect[T](list: List[$monadTypeName[T]]): $monadTypeName[List[T]]")}
+            """.stripMargin
+          abort(msg, pos)
+        }
+
+      private def companionMethodErrorMessage(signature: String) =
+        s"""Please add the method to `${m.tpe}`'s companion object or to `${prefix}`.
+           |It needs to be source compatible with the following signature:
+           |`$signature`
+           |$sourceCompatibilityMessage
+        """.stripMargin
+
+      def map(pos: Tree, instance: TermTree): TermTree =
+        instanceMethod(pos, instance, "map").getOrElse {
+          val msg =
+            s"""Transformation requires the method `map` to transform the result of a monad instance.
+               |${instanceMethodErrorMessage("map[T, U]", s"f: T => U", s"$monadTypeName[U]")}
+            """.stripMargin
+          abort(msg, pos)
+        }
+
+      def flatMap(pos: Tree, instance: TermTree): Tree =
+        instanceMethod(pos, instance, "flatMap").getOrElse {
+          val msg =
+            s"""Transformation requires the method `flatMap` to transform the result of a monad instance.
+               |${instanceMethodErrorMessage("flatMap[T, U]", s"f: T => $monadTypeName[U]", s"$monadTypeName[U]")}
+            """.stripMargin
+          abort(msg, pos)
+        }
+
+      def rescue(pos: Tree, instance: TermTree): Tree =
+        instanceMethod(pos, instance, "rescue").getOrElse {
+          val msg =
+            s"""Transformation requires the method `rescue` to recover from a failure (translate a `catch` clause).
+               |${instanceMethodErrorMessage("collect[T]", s"pf: PartialFunction[Throwable, $monadTypeName[T]]", s"$monadTypeName[T]")}
+               |$errorHandlingMonadNote
+            """.stripMargin
+          abort(msg, pos)
+        }
+
+      def ensure(pos: Tree, instance: TermTree): Tree =
+        instanceMethod(pos, instance, "ensure").getOrElse {
+          val msg =
+            s"""Transformation requires the method `ensure` to execute code regardless of the outcome of the
+               |execution (translate a `finally` clause).
+               |${instanceMethodErrorMessage("rescue[T]", s"f: => Unit", s"$monadTypeName[T]")}
+               |$errorHandlingMonadNote
+            """.stripMargin
+          abort(msg, pos)
+        }
+
+      private def instanceMethodErrorMessage(name: String, parameter: String, result: String) =
+        s"""Please add the method to `${m.tpe}` or to `$prefix`.
+           |It needs to be source compatible with the following signature:
+           |As a `${m.tpe}` method: `def $name($parameter): $result`
+           |As a `$prefix` method: `def $name[T](m: $monadTypeName[T])($parameter): $result`
+           |$sourceCompatibilityMessage
+        """.stripMargin
+
+      private val errorHandlingMonadNote =
+        """Note that this kind of construct (`try`/`catch`/`finally`) can't be used with monads
+          |that don't represent a computation and/or don't handle exceptions (e.g. `Option`)
+        """.stripMargin
+
+      private def instanceMethod(pos: Tree, instance: TermTree, name: String) =
+        this.method(prefix, prefix.tpe, name).map(t => q"$t($instance)")
+          .orElse(this.method(instance, m.tpe, name))
+
+      private def companionMethod(pos: Tree, name: String) =
+        method(prefix, prefix.tpe, name)
+          .orElse(method(Ident(m.tpe.show), m.tpe.companion.get.info, name))
+
+      private def method(instance: TermTree, tpe: Type, name: String) =
+        find(tpe, name).map(_ => Select(instance, name))
+
+      private def find(tpe: Type, method: String) =
+        tpe.method(method) match {
+          case head :: tail => Some(head)
+          case Nil => None
+        }
+    }
+
+    tree
+  }
+}
+
+
+trait MonadlessOption extends Monadless[Option] {
+
+  def collect[T](list: List[Option[T]]): Option[List[T]] =
+    list.foldLeft(Option(List.empty[T])) {
+      (acc, item) =>
+        for {
+          l <- acc
+          i <- item
+        } yield l :+ i
+    }
+}
+
+object MonadlessOption extends MonadlessOption

--- a/macros/src/main/scala/gestalt/macros/Monadless.scala
+++ b/macros/src/main/scala/gestalt/macros/Monadless.scala
@@ -14,7 +14,7 @@ trait Monadless[Monad[_]] {
   */
 
   def lift[T](body: T)(implicit m: toolbox.WeakTypeTag[Monad[_]]): Monad[T] = meta {
-    val tree = Transformer(toolbox)(this, body)(m)
+    val tree = Transformer(toolbox)(this, body)
     toolbox.traverse(tree) {
       case tree @ q"$pack.unlift[$t]($v)" =>
         toolbox.error("Unsupported unlift position", tree)
@@ -35,7 +35,7 @@ object Monadless {
 
 object Transformer {
 
-  def apply(toolbox: Toolbox)(prefix: toolbox.TermTree, tree: toolbox.TermTree)(m: toolbox.WeakTypeTag[_]): toolbox.Tree = {
+  def apply(toolbox: Toolbox)(prefix: toolbox.TermTree, tree: toolbox.TermTree)(implicit m: toolbox.WeakTypeTag[_]): toolbox.Tree = {
     import toolbox._
 
     def toParam(name: String) = Param(emptyMods, name, None, None)

--- a/macros/src/main/scala/gestalt/macros/Monadless.scala
+++ b/macros/src/main/scala/gestalt/macros/Monadless.scala
@@ -291,7 +291,7 @@ object Transformer {
 
       private def companionMethod(pos: Tree, name: String) =
         method(prefix, prefix.tpe, name)
-          .orElse(method(Ident(m.tpe.show), m.tpe.companion.get.info, name))
+          .orElse(method(Ident(m.tpe.show), m.tpe.companion.get, name))
 
       private def method(instance: TermTree, tpe: Type, name: String) =
         find(tpe, name).map(_ => Select(instance, name))

--- a/macros/src/main/scala/gestalt/macros/Monadless.scala
+++ b/macros/src/main/scala/gestalt/macros/Monadless.scala
@@ -23,7 +23,7 @@ trait Monadless[Monad[_]] {
 
 
     toolbox.traverse(tree) {
-      case tree @ Applysss(fun, _, _) if fun.hasType && isUnlift(fun.tpe) =>
+      case q"$fun[$tp]($v)" if fun.hasType && isUnlift(fun.tpe) =>
         toolbox.error("Unsupported unlift position", tree)
     }
 
@@ -93,7 +93,7 @@ object Transformer {
     object PureTree {
       def unapply(tree: Tree): Option[Tree] =
         exists(tree) {
-          case Applysss(fun, _, _) if fun.hasType && isUnlift(fun.tpe) => true
+          case q"$fun[$tp]($v)" if fun.hasType && isUnlift(fun.tpe) => true
         } match {
           case true  => None
           case false => Some(tree)
@@ -163,13 +163,13 @@ object Transformer {
           }
 
 
-        case Applysss(fun, _, (v :: Nil) :: Nil) if isUnlift(fun.tpe) => Some(v)
+        case q"$fun[$tp]($v)" if isUnlift(fun.tpe) => Some(v)
 
         case tree: Tree =>
           val unlifts = collection.mutable.ListBuffer.empty[(TermTree, String, TypeTree)]
           val newTree: TermTree =
             transform(tree) {
-              case tree @ Applysss(fun, tp :: Nil, (v :: Nil) :: Nil) if isUnlift(fun.tpe)  =>
+              case q"$fun[$tp]($v)" if isUnlift(fun.tpe) =>
                 val name = fresh()
                 val splice = wrap(tp)
                 unlifts += ((v, name, splice))

--- a/macros/src/main/scala/gestalt/macros/TypeToolbox.scala
+++ b/macros/src/main/scala/gestalt/macros/TypeToolbox.scala
@@ -122,6 +122,19 @@ object TypeToolbox {
   def typeTag[T](x: T)(implicit m: toolbox.WeakTypeTag[T]): String = meta {
     import toolbox._
     val tp = m.tpe.show
-    toolbox.Lit(tp)
+    Lit(tp)
+  }
+
+  def companion[T1, T2]: Boolean = meta {
+    import toolbox._
+    Lit(T1.tpe.companion.get.info =:= T2.tpe)
+  }
+
+  def companionName[T1]: String = meta {
+    import toolbox._
+    T1.tpe.companion match {
+      case Some(tp) => Lit(tp.info.show)
+      case _ => Lit("")
+    }
   }
 }

--- a/macros/src/main/scala/gestalt/macros/TypeToolbox.scala
+++ b/macros/src/main/scala/gestalt/macros/TypeToolbox.scala
@@ -127,13 +127,13 @@ object TypeToolbox {
 
   def companion[T1, T2]: Boolean = meta {
     import toolbox._
-    Lit(T1.tpe.companion.get.info =:= T2.tpe)
+    Lit(T1.tpe.companion.get =:= T2.tpe)
   }
 
   def companionName[T1]: String = meta {
     import toolbox._
     T1.tpe.companion match {
-      case Some(tp) => Lit(tp.info.show)
+      case Some(tp) => Lit(tp.show)
       case _ => Lit("")
     }
   }

--- a/macros/src/test/scala/gestalt/macros/Driver.scala
+++ b/macros/src/test/scala/gestalt/macros/Driver.scala
@@ -9,6 +9,7 @@ object Driver {
     new DefMacroTest
     new QuasiquoteTest
     new TypeToolboxTest
+    new MonadlessOptionTest
 
     var success = false
     var total = 0

--- a/macros/src/test/scala/gestalt/macros/MonadlessOptionTest.scala
+++ b/macros/src/test/scala/gestalt/macros/MonadlessOptionTest.scala
@@ -24,7 +24,6 @@ class MonadlessOptionTest extends TestSuite {
     assert(lift { unlift(one) + 1 } === Some(2))
   }
 
-  /*
   test("flatMap") {
     assert(
       lift {
@@ -32,5 +31,5 @@ class MonadlessOptionTest extends TestSuite {
         a + unlift(two)
       } === Some(3)
     )
-  } */
+  }
 }

--- a/macros/src/test/scala/gestalt/macros/MonadlessOptionTest.scala
+++ b/macros/src/test/scala/gestalt/macros/MonadlessOptionTest.scala
@@ -1,0 +1,35 @@
+import scala.gestalt._
+import Decorators._
+
+class MonadlessOptionTest extends TestSuite {
+  import MonadlessOption._
+
+  def get[T](t: Option[T]) = t.get
+
+  def fail[T]: T = throw new Exception
+
+  val one = Option(1)
+  val two = Option(2)
+
+  test("apply") {
+    assert(lift {  1 } === Some(1))
+  }
+
+  /*
+  test("collect") {
+    assert(lift { unlift(one) + unlift(two) } === Some(3))
+  }
+
+  test("map") {
+    assert(lift { unlift(one) + 1 } === Some(3))
+  }
+
+  test("flatMap") {
+    assert(
+      lift {
+        val a = unlift(one)
+        a + unlift(two)
+      } === Some(3)
+    )
+  } */
+}

--- a/macros/src/test/scala/gestalt/macros/MonadlessOptionTest.scala
+++ b/macros/src/test/scala/gestalt/macros/MonadlessOptionTest.scala
@@ -15,11 +15,11 @@ class MonadlessOptionTest extends TestSuite {
     assert(lift {  1 } === Some(1))
   }
 
-  /*
   test("collect") {
     assert(lift { unlift(one) + unlift(two) } === Some(3))
   }
 
+  /*
   test("map") {
     assert(lift { unlift(one) + 1 } === Some(3))
   }

--- a/macros/src/test/scala/gestalt/macros/MonadlessOptionTest.scala
+++ b/macros/src/test/scala/gestalt/macros/MonadlessOptionTest.scala
@@ -19,11 +19,12 @@ class MonadlessOptionTest extends TestSuite {
     assert(lift { unlift(one) + unlift(two) } === Some(3))
   }
 
-  /*
+
   test("map") {
-    assert(lift { unlift(one) + 1 } === Some(3))
+    assert(lift { unlift(one) + 1 } === Some(2))
   }
 
+  /*
   test("flatMap") {
     assert(
       lift {

--- a/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
+++ b/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
@@ -158,7 +158,7 @@ class TypeToolboxTest extends TestSuite {
     class B
     object C
     assert(companion[A, A.type])
-    assert(companionName[A] == "A")
+    assert(companionName[A] == "A.type")
     assert(companionName[A.type] == "A")
     assert(companionName[B] == "")
     assert(companionName[C.type] == "")

--- a/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
+++ b/macros/src/test/scala/gestalt/macros/TypeToolboxTest.scala
@@ -151,4 +151,16 @@ class TypeToolboxTest extends TestSuite {
     assert(typeTag(3) == "Int")
     assert(typeTag(Some(4)) == "Some[Int]")
   }
+
+  test("companion") {
+    class A
+    object A
+    class B
+    object C
+    assert(companion[A, A.type])
+    assert(companionName[A] == "A")
+    assert(companionName[A.type] == "A")
+    assert(companionName[B] == "")
+    assert(companionName[C.type] == "")
+  }
 }

--- a/src/main/scala/gestalt/Quote.scala
+++ b/src/main/scala/gestalt/Quote.scala
@@ -7,6 +7,7 @@ import scala.compat.Platform.EOL
 /** Lift scala.meta trees as t.trees */
 abstract class Quote(val t: Toolbox, val toolboxName: String) {
   import Quasiquote.Hole
+  import t._
 
   type Quasi = m.internal.ast.Quasi
 
@@ -66,7 +67,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
           require(prefix.isEmpty)
           if (isTerm) loop(rest, Some(t.Infix(acc.get, "++", liftQuasi(quasi))), Nil)
           else {
-            t.error(m.internal.parsers.Messages.QuasiquoteAdjacentEllipsesInPattern(quasi.rank), enclosingTree)
+            t.error(m.internal.parsers.Messages.QuasiquoteAdjacentEllipsesInPattern(quasi.rank), enclosingTree.pos)
             t.Lit(null)
           }
         }
@@ -97,11 +98,11 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
       if (treess.flatten.length == 1) liftQuasi(tripleDotQuasis(0))
       else {
         t.error("implementation restriction: can't mix ...$ with anything else in parameter lists." +
-          EOL + "See https://github.com/scalameta/scalameta/issues/406 for details.", enclosingTree)
+          EOL + "See https://github.com/scalameta/scalameta/issues/406 for details.", enclosingTree.pos)
         t.Lit(null)
       }
     } else {
-      t.error(m.internal.parsers.Messages.QuasiquoteAdjacentEllipsesInPattern(2), enclosingTree)
+      t.error(m.internal.parsers.Messages.QuasiquoteAdjacentEllipsesInPattern(2), enclosingTree.pos)
       t.Lit(null)
     }
   }
@@ -231,7 +232,7 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
       case Seq(quasi: Quasi) => return liftQuasi(quasi)
       case _ =>
         if (!isTerm) {
-          t.error("Match modifiers in syntax is problematic and not supported. Match the modifiers with a variable instead or $_ to ignore them.", enclosingTree)
+          t.error("Match modifiers in syntax is problematic and not supported. Match the modifiers with a variable instead or $_ to ignore them.", enclosingTree.pos)
           return t.Ident("_")
         }
     }

--- a/src/main/scala/gestalt/Toolbox.scala
+++ b/src/main/scala/gestalt/Toolbox.scala
@@ -6,15 +6,13 @@ trait Toolbox extends Trees with Types with Denotations with Symbols with TypeTa
   /** get the location where the def macro is used */
   def currentLocation: Location
 
-  /** diagnostics - the implementation takes the position from the tree */
-  def error(message: String, tree: Tree): Unit
+  /** diagnostics */
+  def error(message: String, pos: Pos): Unit
 
-  /** stop macro transform - the implementation takes the position from the tree */
-  def abort(message: String, tree: Tree): Nothing
+  /** stop macro transform */
+  def abort(message: String, pos: Pos): Nothing
 
   /** generate fresh unique name */
   def fresh(prefix: String = "$local"): String
 }
-
-
 

--- a/src/main/scala/gestalt/Trees.scala
+++ b/src/main/scala/gestalt/Trees.scala
@@ -1,8 +1,22 @@
 package scala.gestalt
 
+trait Positions { this: Trees =>
+  // it's safe to assume type trees and untyped trees use the same modelling of position
+  type Pos
+
+  implicit class TreePos(tree: Tree) {
+    def pos: Pos = Pos.pos(tree)
+  }
+
+  val Pos: PositionImpl
+  trait PositionImpl {
+    def pos(tree: Tree): Pos
+  }
+}
+
 trait Trees extends Params with TypeParams with
   ValDefs with ValDecls with DefDefs with DefDecls with
-  Classes with Traits with Objects {
+  Classes with Traits with Objects with Positions with TreeOps {
   // safety by construction -- implementation can have TypeTree = Tree
   type Tree     >: Null <: AnyRef
   type TypeTree >: Null <: Tree
@@ -21,6 +35,7 @@ trait Trees extends Params with TypeParams with
   type DefDecl   <: DefTree
   type Self      <: DefTree
   type InitCall  <: Tree
+
 
   type Mods >: Null <: Modifiers
 
@@ -407,25 +422,14 @@ trait Trees extends Params with TypeParams with
       def recur(acc: Seq[Seq[TermTree]], term: TermTree): (TermTree, Seq[Seq[TermTree]]) = term match {
         case Apply(fun, args) => recur(args +: acc, fun) // inner-most is in the front
         case fun => (fun, acc)
-
       }
 
       Some(recur(Nil, call))
     }
   }
+}
 
-  object Applysss {
-    def unapply(tree: TermTree): Option[(TermTree, Seq[TypeTree], Seq[Seq[TermTree]])] = tree match {
-      case ApplyType(fun, targs) =>
-        Some((fun, targs, Nil))
-      case Apply(fun, args) =>
-        val Some((f, targs, argss)) = unapply(fun)
-        Some((f, targs, argss :+ args))
-      case _ =>
-        Some((tree, Nil, Nil))
-    }
-  }
-
+trait TreeOps { this: Trees =>
   // traverser
   def traverse(tre: Tree)(pf: PartialFunction[Tree, Unit]): Unit
   def exists(tree: Tree)(pf: PartialFunction[Tree, Boolean]): Boolean
@@ -487,8 +491,8 @@ trait DefDefs { this: Trees =>
     def paramss: Seq[Seq[Param]] = DefDef.paramss(tree)
     def name: String = DefDef.name(tree)
     def tptOpt: Option[TypeTree] = DefDef.tptOpt(tree)
-    def rhs: Tree = DefDef.rhs(tree)
-    def copy(rhs: Tree = this.rhs): DefDef = DefDef.copyRhs(tree)(rhs)
+    def rhs: TermTree = DefDef.rhs(tree)
+    def copy(rhs: TermTree = this.rhs): DefDef = DefDef.copyRhs(tree)(rhs)
   }
 
   val DefDef: DefDefImpl
@@ -500,7 +504,7 @@ trait DefDefs { this: Trees =>
     def name(tree: DefDef): String
     def tptOpt(tree: DefDef): Option[TypeTree]
     def rhs(tree: DefDef): TermTree
-    def copyRhs(tree: DefDef)(rhs: Tree): DefDef
+    def copyRhs(tree: DefDef)(rhs: TermTree): DefDef
     def get(tree: Tree): Option[DefDef]
     def unapply(tree: Tree): Option[(Mods, String, Seq[TypeParam], Seq[Seq[Param]], Option[TypeTree], TermTree)]
   }
@@ -676,4 +680,3 @@ trait Objects { this: Trees =>
     def unapply(tree: Tree): Option[Object] = Object.get(tree)
   }
 }
-

--- a/src/main/scala/gestalt/Types.scala
+++ b/src/main/scala/gestalt/Types.scala
@@ -1,7 +1,7 @@
 package scala.gestalt
 
 trait Types extends MethodTypes { self: Toolbox =>
-  type Type
+  type Type >: Null <: AnyRef
 
   implicit class TypeOps(tp: Type) {
     def =:=(tp2: Type) = Type.=:=(tp, tp2)
@@ -14,6 +14,7 @@ trait Types extends MethodTypes { self: Toolbox =>
     def methodsIn: Seq[Denotation] = Type.methodsIn(tp)
     def method(name: String): Seq[Denotation] = Type.method(tp, name)
     def methods: Seq[Denotation] = Type.methods(tp)
+    def companion: Option[Denotation] = Type.companion(tp)
     def show: String = Type.show(tp)
   }
 
@@ -64,6 +65,11 @@ trait Types extends MethodTypes { self: Toolbox =>
 
     /** get all non-private methods declared or inherited */
     def methods(tp: Type): Seq[Denotation]
+
+    /** If `tp` points to a class, the module class of its companion object.
+     *  If `tp` points to an object, its companion class.
+     */
+    def companion(tp: Type): Option[Denotation]
   }
 
 
@@ -76,7 +82,7 @@ trait Types extends MethodTypes { self: Toolbox =>
 }
 
 trait MethodTypes { this: Types =>
-  type MethodType
+  type MethodType >: Null <: Type
 
   implicit class MethodTypeOps(tp: MethodType) {
     def paramInfos: Seq[Type] = MethodType.paramInfos(tp)

--- a/src/main/scala/gestalt/Types.scala
+++ b/src/main/scala/gestalt/Types.scala
@@ -22,6 +22,7 @@ trait Types extends MethodTypes { self: Toolbox =>
 
   implicit class TreeTypeOps(tree: Tree) {
     def tpe: Type = Type.typeOf(tree)
+    def hasType: Boolean = Type.hasType(tree)
   }
 
   val Type: TypeImpl
@@ -43,6 +44,13 @@ trait Types extends MethodTypes { self: Toolbox =>
 
     /** type associated with the tree */
     def typeOf(tree: Tree): Type
+
+    /** whether the tree is typed or not
+     *
+     *  @note this is temporary, once we separate typed trees from untped
+     *        trees, this should be removed.
+     */
+    def hasType(tree: Tree): Boolean
 
     /** does the type refer to a case class? */
     def isCaseClass(tp: Type): Boolean

--- a/src/main/scala/gestalt/Types.scala
+++ b/src/main/scala/gestalt/Types.scala
@@ -16,6 +16,8 @@ trait Types extends MethodTypes { self: Toolbox =>
     def methods: Seq[Denotation] = Type.methods(tp)
     def companion: Option[Type] = Type.companion(tp)
     def show: String = Type.show(tp)
+    def widen: Type = Type.widen(tp)
+    def denot: Option[Denotation] = Type.denot(tp)
   }
 
   implicit class TreeTypeOps(tree: Tree) {
@@ -70,6 +72,12 @@ trait Types extends MethodTypes { self: Toolbox =>
      *  If `tp` points to an object, its companion class.
      */
     def companion(tp: Type): Option[Type]
+
+    /** widen singleton types */
+    def widen(tp: Type): Type
+
+    /** denotation associated with the type */
+    def denot(tp: Type): Option[Denotation]
   }
 
 

--- a/src/main/scala/gestalt/Types.scala
+++ b/src/main/scala/gestalt/Types.scala
@@ -14,7 +14,7 @@ trait Types extends MethodTypes { self: Toolbox =>
     def methodsIn: Seq[Denotation] = Type.methodsIn(tp)
     def method(name: String): Seq[Denotation] = Type.method(tp, name)
     def methods: Seq[Denotation] = Type.methods(tp)
-    def companion: Option[Denotation] = Type.companion(tp)
+    def companion: Option[Type] = Type.companion(tp)
     def show: String = Type.show(tp)
   }
 
@@ -69,7 +69,7 @@ trait Types extends MethodTypes { self: Toolbox =>
     /** If `tp` points to a class, the module class of its companion object.
      *  If `tp` points to an object, its companion class.
      */
-    def companion(tp: Type): Option[Denotation]
+    def companion(tp: Type): Option[Type]
   }
 
 

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -506,6 +506,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
 
     def unapply(tree: Tree): Option[(TermTree, Seq[Tree])] = tree match {
       case c.Match(expr, cases) => Some((expr, cases))
+      case _ => None
     }
   }
 
@@ -954,6 +955,14 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
         else None
       else None
     }
+
+    def widen(tp: Type): Type = tp.widen
+
+    def denot(tp: Type): Option[Denotation] = tp match {
+      case tp: Types.NamedType => Some(tp.denot)
+      case tp: Types.TypeProxy => denot(tp.underlying)
+      case _ => None
+    }
   }
 
   object ByNameType extends ByNameTypeImpl {
@@ -965,7 +974,9 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
 
   object MethodType extends MethodTypeImpl {
     def paramInfos(tp: MethodType): Seq[Type] = tp.paramInfos
-    def instantiate(tp: MethodType)(params: Seq[Type]): Type = tp.instantiate(params)
+    def instantiate(tp: MethodType)(params: Seq[Type]): Type = {
+      tp.instantiate(params.toList)
+    }
     def unapply(tp: Type): Option[MethodType] = tp match {
       case tp: Types.MethodType => Some(tp)
       case _ => None

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -944,13 +944,13 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       )
     }
 
-    def companion(tp: Type): Option[Denotation] = {
+    def companion(tp: Type): Option[Type] = {
       val clazz = tp.widenSingleton.classSymbol
       if (clazz.exists)
         if (clazz.is(Flags.Module) && clazz.companionClass.exists)
-          Some(clazz.companionClass.namedType.denot)
-        else if (clazz.companionModule.exists)
-          Some(clazz.companionModule.namedType.denot)
+          Some(clazz.companionClass.namedType)
+        else if (!clazz.is(Flags.Module) && clazz.companionModule.exists)
+          Some(clazz.companionModule.namedType)
         else None
       else None
     }

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -843,10 +843,12 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
 
   /*------------------------------- traversers -------------------------------------*/
   def traverse(tree: Tree)(pf: PartialFunction[Tree, Unit]): Unit =
-    new d.TreeTraverser {
-      def traverse(tree: Tree)(implicit ctx: Context) =
-        pf.lift(tree).getOrElse(super.traverseChildren(tree))
-    }.traverse(tree)
+     new d.UntypedTreeMap() {
+      override def transform(tree: Tree)(implicit ctx: Context) = {
+        pf.lift(tree).getOrElse(super.transform(tree))
+        tree
+      }
+    }.transform(tree)
 
   def exists(tree: Tree)(pf: PartialFunction[Tree, Boolean]): Boolean = {
     var r = false

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -894,6 +894,8 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
     /** type associated with the tree */
     def typeOf(tree: Tree): Type = tree.tpe
 
+    def hasType(tree: Tree): Boolean = tree.hasType
+
     /** does the type refer to a case class? */
     def isCaseClass(tp: Type): Boolean = tp.classSymbol.is(Flags.Case)
 

--- a/src/main/scala/gestalt/dotty/Expander.scala
+++ b/src/main/scala/gestalt/dotty/Expander.scala
@@ -140,7 +140,7 @@ object Expander {
         case e: Exception =>
           ctx.error("error occurred while expanding macro: \n" + e.getMessage, tree.pos)
           e.printStackTrace()
-          tree
+          untpd.Literal(Constant(null)).withPos(tree.pos)
       }
     case _ =>
       ctx.warning(s"Unknown macro expansion: $tree")


### PR DESCRIPTION
This is an example implementation of a subset of `Monadless` in gestalt, the tests pass.

A list of additions in semantic API:

- add `WeakTypeTag`
- add `TypedSplice`
- add `Type.companion`, `Type.widen` and `Type.denot`
- add extractor and API for `MethodType`
- add extractor for `ByNameType`

Some findings or changes:

- Two bugs of scala.meta quasiquotes
- Fix one bug about `UntypedTreeMap` in Dotty
- Synthesise `prefix` if it's `null` for def macros
- Todo: missing auto lifting from String to identifier makes `quasiquote` inconvenient
- Fix bug in quasiquote lifting of ValDefs
