### PR TITLE
Fix anonymous class creation

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -121,12 +121,16 @@ object trees {
          def next(): $T = ???
        }"""
   }
+
   def abcdObject(): AnyRef = meta {
-    val tree =
-      q"""new Object {
+    q"""new Object {
         override def toString = "abcd"
       }"""
-    tree
+  }
+  def abcdObject2(): AnyRef = meta {
+    q"""new java.lang.Object {
+        override def toString = "abcd"
+      }"""
   }
 }
 

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -107,6 +107,13 @@ object trees {
   def ident(a: Any): Any = meta {
     q"$a"
   }
+
+  def iterator(): Iterator[Nothing] = meta {
+    q"""new Iterator[Nothing]{
+         def hasNext = false
+         def next() = ???
+       }"""
+  }
 }
 
 object Inheritance {

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -114,6 +114,13 @@ object trees {
          def next() = ???
        }"""
   }
+
+  def typedIterator[T](): Iterator[T] = meta {
+    q"""new Iterator[$T]{
+         def hasNext = false
+         def next(): $T = ???
+       }"""
+  }
 }
 
 object Inheritance {

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -121,6 +121,13 @@ object trees {
          def next(): $T = ???
        }"""
   }
+  def abcdObject(): AnyRef = meta {
+    val tree =
+      q"""new Object {
+        override def toString = "abcd"
+      }"""
+    tree
+  }
 }
 
 object Inheritance {

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -191,4 +191,8 @@ class DefMacroTest extends TestSuite {
     implicit val x: Int = 1
     assert(g(1)(2) == 2)
   }
+
+  test("create anonymous class") {
+    assert(trees.iterator().hasNext == false)
+  }
 }

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -196,5 +196,6 @@ class DefMacroTest extends TestSuite {
     assert(trees.iterator().hasNext == false)
     assert(trees.typedIterator[String]().hasNext == false)
     assert(trees.abcdObject().toString == "abcd")
+    assert(trees.abcdObject2().toString == "abcd")
   }
 }

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -194,5 +194,6 @@ class DefMacroTest extends TestSuite {
 
   test("create anonymous class") {
     assert(trees.iterator().hasNext == false)
+    assert(trees.typedIterator[String]().hasNext == false)
   }
 }

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -195,5 +195,6 @@ class DefMacroTest extends TestSuite {
   test("create anonymous class") {
     assert(trees.iterator().hasNext == false)
     assert(trees.typedIterator[String]().hasNext == false)
+    assert(trees.abcdObject().toString == "abcd")
   }
 }

--- a/src/main/scala/gestalt/Quote.scala
+++ b/src/main/scala/gestalt/Quote.scala
@@ -149,6 +149,8 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     def extractFun(tree: m.Tree): (t.TermTree, t.TermTree, t.TermTree) = tree match {
       case m.Term.ApplyType(m.Ctor.Ref.Select(qual, m.Ctor.Ref.Name(name)), targs) =>
         (scalaSome.appliedTo(lift(qual)), t.Lit(name), liftSeq(targs))
+      case m.Ctor.Ref.Select(qual, m.Ctor.Ref.Name(name)) =>
+        (scalaSome.appliedTo(lift(qual)), t.Lit(name), liftSeq(Nil))
       case m.Term.ApplyType(m.Ctor.Ref.Name(name), targs) =>
         (scalaNone, t.Lit(name), liftSeq(targs))
       case m.Ctor.Ref.Name(name) =>

--- a/src/main/scala/gestalt/Quote.scala
+++ b/src/main/scala/gestalt/Quote.scala
@@ -131,8 +131,11 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     if (quasi.rank > 0) return liftQuasi(quasi.tree.asInstanceOf[Quasi], quasi.rank, optional)
 
     def arg(i: Int) =
-      if (!isTerm && optional) scalaSome.appliedTo(args(i).asInstanceOf[t.TermTree])
-      else args(i).asInstanceOf[t.TermTree]
+      if (optional) {
+        scalaSome.appliedTo(args(i).asInstanceOf[t.TermTree])
+      } else {
+        args(i).asInstanceOf[t.TermTree]
+      }
 
     quasi.tree match {
       case m.Term.Name(Hole(i)) => arg(i)

--- a/src/main/scala/gestalt/Quote.scala
+++ b/src/main/scala/gestalt/Quote.scala
@@ -144,9 +144,9 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     * {{{(tree: m.Tree[A]) => t.Tree[t.Tree[A]]}}} */
   def liftInitCall(tree: m.Tree): t.TermTree = {
     def extractFun(tree: m.Tree): (t.TermTree, t.TermTree, t.TermTree) = tree match {
-      case m.Type.Apply(m.Ctor.Ref.Select(qual, m.Ctor.Ref.Name(name)), targs) =>
+      case m.Term.ApplyType(m.Ctor.Ref.Select(qual, m.Ctor.Ref.Name(name)), targs) =>
         (scalaSome.appliedTo(lift(qual)), t.Lit(name), liftSeq(targs))
-      case m.Type.Apply(m.Ctor.Ref.Name(name), targs) =>
+      case m.Term.ApplyType(m.Ctor.Ref.Name(name), targs) =>
         (scalaNone, t.Lit(name), liftSeq(targs))
       case m.Ctor.Ref.Name(name) =>
         (scalaNone, t.Lit(name), liftSeq(Nil))

--- a/src/main/scala/gestalt/Quote.scala
+++ b/src/main/scala/gestalt/Quote.scala
@@ -167,8 +167,13 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
 
   /** {{{(trees: Seq[t.Tree[t.Tree[A]]]) => t.Tree[Seq[t.Tree[A]]]}}} */
   def liftSeqTrees(trees: Seq[t.TermTree]): t.TermTree = trees match {
-    case head :: rest => t.Infix(head, "::", liftSeqTrees(rest))
-    case _ => scalaNil
+    case head :: rest =>
+      // Infix is sugar-less
+      // the List is constructed as Nil.::(c).::(b).::(a)
+      // Not a :: b :: c :: Nil
+      t.Infix(liftSeqTrees(rest), "::", head)
+    case _ =>
+      scalaNil
   }
 
   /**

--- a/src/main/scala/gestalt/Trees.scala
+++ b/src/main/scala/gestalt/Trees.scala
@@ -413,8 +413,8 @@ trait Trees extends Params with TypeParams with
 
   // helper
   def ApplySeq(fun: TermTree, argss: Seq[Seq[TermTree]]): Tree = argss match {
-    case args :: rest => rest.foldLeft(Apply(fun, args)) { (acc, args) => Apply(acc, args) }
-    case _ => fun
+   case args :: rest => rest.foldLeft(Apply(fun, args)) { (acc, args) => Apply(acc, args) }
+   case _ => fun
   }
 
   object ApplySeq {

--- a/src/main/scala/gestalt/Trees.scala
+++ b/src/main/scala/gestalt/Trees.scala
@@ -392,7 +392,7 @@ trait Trees extends Params with TypeParams with
   // helpers
   def ApplySeq(fun: TermTree, argss: Seq[Seq[TermTree]]): Tree = argss match {
     case args :: rest => rest.foldLeft(Apply(fun, args)) { (acc, args) => Apply(acc, args) }
-    case _ => Apply(fun, Nil)
+    case _ => fun
   }
 
   object ApplySeq {

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -177,7 +177,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
   // qual.T[A, B](x, y)(z)
   object InitCall extends InitCallImpl {
     def apply(qual: Option[Tree], name: String, targs: Seq[TypeTree], argss: Seq[Seq[TermTree]]): InitCall = {
-      val select = if (qual.isEmpty) d.Ident(name.toTermName) else d.Select(qual.get, name.toTypeName)
+      val select = if (qual.isEmpty) d.Ident(name.toTypeName) else d.Select(qual.get, name.toTypeName)
       val fun = if (targs.size == 0) select else TypeApply(select, targs.toList)
       ApplySeq(fun, argss).withPosition
     }


### PR DESCRIPTION
* Fixed MatchError when expending quasiquotes by matching on `m.Term.ApplyType`, not `m.Type.Apply`. This is what the meta parser gives us.
* Fixed "toolbox.Ident does not have a `::` method" exception. Using `list.::(item)` 
* Now it is possible to splice in typeTrees in quasiquotes. Always wrapping the value in an `Some` if it expects an `Option`.
* Fixed Match error in Namer:863 and "Iterator does not take type arguments". Namer and Typer expect the parent to be a type not a term. Using `name.toTypeName` instead of `name.toTermName`
* Fixed MatchError when expending quasiquotes by handling the forth case (qualifier present, no type parameter).
* Added tests for all of these cases.

This is essential for JSON macros #41