### PR TITLE
Fix partial function creation

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -135,6 +135,13 @@ object trees {
         override def toString = "abcd"
       }"""
   }
+
+  def pfCollect(): Option[String] = meta {
+    q"""Some(3).collect{
+         case 2 => "two"
+         case 3 => "three"
+         }"""
+  }
 }
 
 object Inheritance {

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -198,4 +198,8 @@ class DefMacroTest extends TestSuite {
     assert(trees.abcdObject().toString == "abcd")
     assert(trees.abcdObject2().toString == "abcd")
   }
+
+  test("create partial function") {
+    assert(trees.pfCollect() == Some("three"))
+  }
 }

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -533,10 +533,10 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
 
   object PartialFunction extends PartialFunctionImpl {
     def apply(cases: Seq[Tree]): TermTree =
-      d.Match(d.Thicket(Nil), cases.toList.asInstanceOf[List[d.CaseDef]]).withPosition
+      d.Match(d.EmptyTree, cases.toList.asInstanceOf[List[d.CaseDef]]).withPosition
 
     def unapply(tree: Tree): Option[Seq[Tree]] = tree match {
-      case c.Match(c.Thicket(Nil), cases) => Some(cases)
+      case c.Match(d.EmptyTree, cases) => Some(cases)
       case _ => None
     }
   }


### PR DESCRIPTION
Fixed partial function creation by using the `d.EmptyTree` singleton value. The Typer was failing when using `d.Thicket(Nil)`.