### PR TITLE
Fix new instance creation

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -101,6 +101,12 @@ object trees {
   def some3(): Option[Int] = meta {
     q"Some(3)"
   }
+  def some3Explicit(): Option[Int] = meta {
+    q"new Some(3)"
+  }
+  def some3ExplicitTyped(): Option[Int] = meta {
+    q"new Some[Int](3)"
+  }
   def five(): Int = meta {
     q"5"
   }

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -202,4 +202,9 @@ class DefMacroTest extends TestSuite {
   test("create partial function") {
     assert(trees.pfCollect() == Some("three"))
   }
+
+  test("create class instance") {
+    assert(trees.some3Explicit() == Some(3))
+    assert(trees.some3ExplicitTyped() == Some(3))
+  }
 }

--- a/src/main/scala/gestalt/Quote.scala
+++ b/src/main/scala/gestalt/Quote.scala
@@ -144,35 +144,37 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     }
   }
 
+  private object TypeArguments {
+    def unapply(tree: m.Tree) = tree match {
+      case m.Term.ApplyType(inner, targs) => Some(inner -> liftSeq(targs))
+      case inner => Some(inner -> liftSeq(Nil))
+    }
+  }
+
+  private object Qualifier {
+    def unapply(tree: m.Tree) = tree match {
+      case m.Ctor.Ref.Select(qual, inner) => Some(inner -> scalaSome.appliedTo(lift(qual)))
+      case inner => Some(inner -> scalaNone)
+    }
+  }
+
+  private object Argss {
+    def unapply(tree: m.Tree) = tree match {
+      case m.internal.ast.Helpers.TermApply(inner, argss) => Some(inner -> argss)
+      case inner => Some(inner -> Nil)
+    }
+  }
+
   /** Lift initcall : {{{qual.T[A, B](x, y)(z)}}}
     * {{{(tree: m.Tree[A]) => t.Tree[t.Tree[A]]}}} */
   def liftInitCall(tree: m.Tree): t.TermTree = {
+    val Argss(TypeArguments(Qualifier(m.Ctor.Ref.Name(name), qualOpt), targs), argss) = tree
+    selectToolbox("InitCall").appliedTo(qualOpt, t.Lit(name), targs, liftSeqSeq(argss))
+  }
 
-    object TypeArguments {
-      def unapply(tree: m.Tree) = tree match {
-        case m.Term.ApplyType(inner, targs) => Some(inner -> liftSeq(targs))
-        case inner => Some(inner -> liftSeq(Nil))
-      }
-    }
-
-    object Qualifier {
-      def unapply(tree: m.Tree) = tree match {
-        case m.Ctor.Ref.Select(qual, inner) => Some(inner -> scalaSome.appliedTo(lift(qual)))
-        case inner => Some(inner -> scalaNone)
-      }
-    }
-
-    def initCall(ctor: m.Tree, argss: Seq[Seq[m.Tree]]): t.TermTree = {
-      val TypeArguments(Qualifier(m.Ctor.Ref.Name(name), qualOpt), targs) = ctor
-      selectToolbox("InitCall").appliedTo(qualOpt, t.Lit(name), targs, liftSeqSeq(argss))
-    }
-
-    tree match {
-      case m.internal.ast.Helpers.TermApply(ctor, argss) =>
-        initCall(ctor, argss)
-      case _ =>
-        initCall(tree, Nil)
-    }
+  def liftNewInstance(tree: m.Tree): t.TermTree = {
+    val Argss(TypeArguments(Qualifier(m.Ctor.Ref.Name(name), qualOpt), targs), argss) = tree
+    selectToolbox("NewInstance").appliedTo(qualOpt, t.Lit(name), targs, liftSeqSeq(argss))
   }
 
   /** {{{(trees: Seq[t.Tree[t.Tree[A]]]) => t.Tree[Seq[t.Tree[A]]]}}} */
@@ -395,13 +397,12 @@ abstract class Quote(val t: Toolbox, val toolboxName: String) {
     case m.Term.ForYield(enums, body) =>
       selectToolbox("For.ForYield").appliedTo(liftSeq(enums), lift(body))
     case m.Term.New(m.Template(Nil, Seq(mctor), m.Term.Param(Nil, m.Name.Anonymous(), None, None), None)) =>
-      selectToolbox("New").appliedTo(liftInitCall(mctor))
+      liftNewInstance(mctor)
     case m.Term.New(m.Template(_, parents, self, stats)) =>
       // parentCalls: t.Tree[Seq[t.Tree[B]]]
       val parentCalls = liftSeqTrees(parents.map(liftInitCall))
       // anonym: t.Tree[t.Tree[C]]
-      val anonym = selectToolbox("AnonymClass").appliedTo(parentCalls, liftSelf(self), liftOptSeq(stats))
-      selectToolbox("New").appliedTo(anonym)
+      selectToolbox("NewAnonymClass").appliedTo(parentCalls, liftSelf(self), liftOptSeq(stats))
     case m.Term.Placeholder() =>
       selectToolbox("Wildcard").appliedTo() // FIXME Wildcard is not defined in toolbox
     case m.Term.Eta(expr) =>

--- a/src/main/scala/gestalt/Trees.scala
+++ b/src/main/scala/gestalt/Trees.scala
@@ -121,6 +121,11 @@ trait Trees extends Params with TypeParams with
     def apply(qual: Option[Tree], name: String, targs: Seq[TypeTree], argss: Seq[Seq[TermTree]]): InitCall
   }
 
+  val NewInstance: NewInstanceImpl
+  trait NewInstanceImpl {
+    def apply(qual: Option[Tree], name: String, targs: Seq[TypeTree]): TermTree
+  }
+
   val SecondaryCtor: SecondaryCtorImpl
   trait SecondaryCtorImpl {
     def apply(mods: Mods, paramss: Seq[Seq[Param]], rhs: TermTree): Tree

--- a/src/main/scala/gestalt/Trees.scala
+++ b/src/main/scala/gestalt/Trees.scala
@@ -85,8 +85,8 @@ trait Trees extends Params with TypeParams with
 
 
   // definition trees
-  val AnonymClass: AnonymClassImpl
-  trait AnonymClassImpl {
+  val NewAnonymClass: NewAnonymClassImpl
+  trait NewAnonymClassImpl {
     def apply(parents: Seq[InitCall], self: Option[Self], stats: Seq[Tree]): DefTree
   }
 
@@ -123,7 +123,7 @@ trait Trees extends Params with TypeParams with
 
   val NewInstance: NewInstanceImpl
   trait NewInstanceImpl {
-    def apply(qual: Option[Tree], name: String, targs: Seq[TypeTree]): TermTree
+    def apply(qual: Option[Tree], name: String, targs: Seq[TypeTree], argss: Seq[Seq[TermTree]]): TermTree
   }
 
   val SecondaryCtor: SecondaryCtorImpl
@@ -270,12 +270,6 @@ trait Trees extends Params with TypeParams with
     def GenFrom(pat: TermTree, rhs: TermTree): Tree
     def GenAlias(pat: TermTree, rhs: TermTree): Tree
     def Guard(cond: TermTree): Tree
-  }
-
-  val New: NewImpl
-  trait NewImpl {
-    // can be InitCall or AnonymClass
-    def apply(tpe: Tree): TermTree
   }
 
   val Named: NamedImpl

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -137,11 +137,11 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
 
   /*------------------------------ trees ------------------------------*/
 
-  object AnonymClass extends AnonymClassImpl {
+  object NewAnonymClass extends NewAnonymClassImpl {
     def apply(parents: Seq[InitCall], selfOpt: Option[Self], stats: Seq[Tree]): Tree = {
       val init = d.DefDef(nme.CONSTRUCTOR, List(), List(), d.TypeTree(), d.EmptyTree)
       val self = if (selfOpt.isEmpty) d.EmptyValDef else selfOpt.get.asInstanceOf[d.ValDef]
-      d.Template(init, parents.toList, self, stats).withPosition
+      d.New(d.Template(init, parents.toList, self, stats).withPosition)
     }
   }
 
@@ -188,7 +188,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
   object InitCall extends InitCallImpl {
     def apply(qual: Option[Tree], name: String, targs: Seq[TypeTree], argss: Seq[Seq[TermTree]]): InitCall = {
       val select = if (qual.isEmpty) d.Ident(name.toTypeName) else d.Select(qual.get, name.toTypeName)
-      val fun = if (targs.empty) select else TypeApply(select, targs.toList)
+      val fun = if (targs.isEmpty) select else TypeApply(select, targs.toList)
       ApplySeq(fun, argss).withPosition
     }
   }
@@ -197,7 +197,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
   object NewInstance extends NewInstanceImpl {
     def apply(qual: Option[Tree], name: String, targs: Seq[TypeTree], argss: Seq[Seq[TermTree]]): TermTree = {
       val select = if (qual.isEmpty) d.Ident(name.toTypeName) else d.Select(qual.get, name.toTypeName)
-      val fun = if (targs.empty) select else TypeApply(select, targs.toList)
+      val fun = if (targs.isEmpty) select else TypeApply(select, targs.toList)
       ApplySeq(d.Select(d.New(fun), nme.CONSTRUCTOR), argss).withPosition
     }
   }
@@ -376,11 +376,6 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
     def GenFrom(pat: TermTree, rhs: TermTree): Tree = d.GenFrom(pat, rhs)
     def GenAlias(pat: TermTree, rhs: TermTree): Tree = d.GenAlias(pat, rhs)
     def Guard(cond: TermTree): Tree = cond
-  }
-
-  object New extends NewImpl {
-    // can be InitCall or AnonymClass
-    def apply(tpe: Tree): TermTree = d.New(tpe).withPosition
   }
 
   object Named extends NamedImpl {

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -188,8 +188,17 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
   object InitCall extends InitCallImpl {
     def apply(qual: Option[Tree], name: String, targs: Seq[TypeTree], argss: Seq[Seq[TermTree]]): InitCall = {
       val select = if (qual.isEmpty) d.Ident(name.toTypeName) else d.Select(qual.get, name.toTypeName)
-      val fun = if (targs.size == 0) select else TypeApply(select, targs.toList)
+      val fun = if (targs.empty) select else TypeApply(select, targs.toList)
       ApplySeq(fun, argss).withPosition
+    }
+  }
+
+  // new qual.T[A, B](x, y)(z)
+  object NewInstance extends NewInstanceImpl {
+    def apply(qual: Option[Tree], name: String, targs: Seq[TypeTree], argss: Seq[Seq[TermTree]]): TermTree = {
+      val select = if (qual.isEmpty) d.Ident(name.toTypeName) else d.Select(qual.get, name.toTypeName)
+      val fun = if (targs.empty) select else TypeApply(select, targs.toList)
+      ApplySeq(d.Select(d.New(fun), nme.CONSTRUCTOR), argss).withPosition
     }
   }
 


### PR DESCRIPTION
A new instance is created by applying the constructor method `<init>` to the arguments, not by calling `New` on the type applied to the arguments. I found this out by running the parser on `new Some[Int](3)`, i.e. a modified version of `dotty/tools/dotc/parsing/parseFile.scala`.

* Created a new constructor `NewInstance`
* Combined `New` and `AnonymClass` into `NewAnonymClass` as discussed in #73 
* Refactor: decomposed `liftInitCall` into multiple always successful, private extractors. This way we do not have to have 2^n cases in a match statement. Reused the same extractors for `liftNewInstance`
* Added tests for new instance creation

Necessary fix for JSON deserialization #41 