### PR TITLE
a simple solution to hygiene problem

### DIFF
--- a/macros/src/main/scala/gestalt/macros/Annotations.scala
+++ b/macros/src/main/scala/gestalt/macros/Annotations.scala
@@ -2,6 +2,7 @@ import scala.annotation.StaticAnnotation
 import scala.collection.immutable.Seq
 
 import scala.gestalt.api._
+import scala.gestalt.options.unsafe
 
 class main extends StaticAnnotation {
   def apply(defn: Any): Any = meta {

--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -1,4 +1,5 @@
 import scala.gestalt.api._
+import scala.gestalt.options.unsafe
 
 object plusObject {
   def apply(a: Int, b: Int): Int = meta {

--- a/macros/src/main/scala/gestalt/macros/Monadless.scala
+++ b/macros/src/main/scala/gestalt/macros/Monadless.scala
@@ -14,7 +14,7 @@ trait Monadless[Monad[_]] {
   */
 
   def lift[T](body: T)(implicit m: WeakTypeTag[Monad[_]]): Monad[T] = meta {
-    val tree: Tree = Transformer(this, body)
+    val tree = Transformer(this, body)
 
     val unliftSym = this.tpe.method("unlift").headOption.map(_.symbol)
     def isUnlift(tp: Type) = tp.denot.map(_.symbol) == unliftSym
@@ -240,7 +240,7 @@ object Transformer {
 
                 Block(iter +: elements, content)
               }
-              Some(q"${Resolve.map(tree.pos, collect).appliedToTypes(types.head.tpe.toTree)}($fun)")
+              Some(Resolve.map(tree.pos, collect).appliedToTypes(types.head.tpe.toTree).appliedTo(fun))
           }
       }
     }

--- a/macros/src/main/scala/gestalt/macros/Optional.scala
+++ b/macros/src/main/scala/gestalt/macros/Optional.scala
@@ -7,6 +7,8 @@ final class Optional[+A >: Null](val value: A) extends AnyVal {
   def isEmpty = value == null
 
   def getOrElse[B >: A](alt: => B)(implicit m: WeakTypeTag[A] @uncheckVar): B = meta {
+    import scala.gestalt.options.unsafe
+
     val temp = fresh("_temp")
     val tempIdent = Ident(temp)
 

--- a/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
+++ b/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
@@ -2,6 +2,7 @@ import scala.annotation.StaticAnnotation
 import scala.collection.immutable.Seq
 
 import scala.gestalt.api._
+import scala.gestalt.options.unsafe
 
 object Quasiquotes {
   implicit class TestHelper(lhs: Any) extends AnyVal {

--- a/macros/src/main/scala/gestalt/macros/TypeToolbox.scala
+++ b/macros/src/main/scala/gestalt/macros/TypeToolbox.scala
@@ -1,4 +1,5 @@
 import scala.gestalt.api._
+import scala.gestalt.options.unsafe
 
 object TypeToolbox {
   /** are the two types equal? */

--- a/src/main/scala/gestalt/api.scala
+++ b/src/main/scala/gestalt/api.scala
@@ -155,13 +155,9 @@ object api extends Toolbox { pkg =>
     }
 
     def select(path: String): TermTree = {
-      val parts = path.split('.')
-
-      val prefix = parts.init.foldLeft[TermTree](tree) { (prefix, name) =>
-        prefix.select(name)
+      parts.foldLeft[TermTree](tree) { (prefix, name) =>
+        Select(prefix, name)
       }
-
-      Select(prefix, parts.last)
     }
   }
 

--- a/src/main/scala/gestalt/api.scala
+++ b/src/main/scala/gestalt/api.scala
@@ -155,6 +155,7 @@ object api extends Toolbox { pkg =>
     }
 
     def select(path: String): TermTree = {
+      val parts = path.split('.')
       parts.foldLeft[TermTree](tree) { (prefix, name) =>
         Select(prefix, name)
       }

--- a/src/main/scala/gestalt/api.scala
+++ b/src/main/scala/gestalt/api.scala
@@ -403,7 +403,10 @@ object api extends Toolbox { pkg =>
   implicit class TypeOps(tp: Type) {
     def =:=(tp2: Type) = Type.=:=(tp, tp2)
     def <:<(tp2: Type) = Type.<:<(tp, tp2)
-    def isCaseClass = Type.isCaseClass(tp)
+    def isCaseClass = Type.classSymbol(tp) match {
+      case Some(cls) => Symbol.isCase(cls)
+      case None      => false
+    }
     def caseFields: Seq[Denotation] = Type.caseFields(tp)
     def fieldIn(name: String): Option[Denotation] = Type.fieldIn(tp, name)
     def fieldsIn: Seq[Denotation] = Type.fieldsIn(tp)
@@ -431,10 +434,20 @@ object api extends Toolbox { pkg =>
   /**--------------------- Symbols ---------------------------------*/
   def Symbol         = toolbox.get.Symbol.asInstanceOf[SymbolImpl]
 
-
   implicit class SymbolOps(sym: Symbol) {
     def name: String = Symbol.name(sym)
     def asSeenFrom(prefix: Type): Type = Symbol.asSeenFrom(sym, prefix)
+    def isCase: Boolean = Symbol.isCase(sym)
+    def isTrait: Boolean = Symbol.isTrait(sym)
+    def isPrivate: Boolean = Symbol.isPrivate(sym)
+    def isProtected: Boolean = Symbol.isProtected(sym)
+    def isOverride: Boolean = Symbol.isOverride(sym)
+    def isFinal: Boolean = Symbol.isFinal(sym)
+    def isImplicit: Boolean = Symbol.isImplicit(sym)
+    def isLazy: Boolean = Symbol.isLazy(sym)
+    def isSealed: Boolean = Symbol.isSealed(sym)
+    def isAbstract: Boolean = Symbol.isAbstract(sym)
+    def isMutable: Boolean = Symbol.isMutable(sym)
   }
 
   /**--------------------- Denotations ---------------------------------*/

--- a/src/main/scala/gestalt/api.scala
+++ b/src/main/scala/gestalt/api.scala
@@ -148,7 +148,7 @@ object api extends Toolbox { pkg =>
       val parts = path.split('.')
 
       val prefix = parts.init.foldLeft[TermTree](tree) { (prefix, name) =>
-        prefix.select(name)
+        Select(prefix, name)
       }
 
       TypeSelect(prefix, parts.last)

--- a/src/main/scala/gestalt/core/Symbols.scala
+++ b/src/main/scala/gestalt/core/Symbols.scala
@@ -10,5 +10,17 @@ trait Symbols { this: Toolbox =>
 
     /** type of a member with respect to a prefix */
     def asSeenFrom(mem: Symbol, prefix: Type): Type
+
+    def isCase(sym: Symbol): Boolean
+    def isTrait(sym: Symbol): Boolean
+    def isPrivate(sym: Symbol): Boolean
+    def isProtected(sym: Symbol): Boolean
+    def isOverride(sym: Symbol): Boolean
+    def isFinal(sym: Symbol): Boolean
+    def isImplicit(sym: Symbol): Boolean
+    def isLazy(sym: Symbol): Boolean
+    def isSealed(sym: Symbol): Boolean
+    def isAbstract(sym: Symbol): Boolean
+    def isMutable(sym: Symbol): Boolean
   }
 }

--- a/src/main/scala/gestalt/core/Trees.scala
+++ b/src/main/scala/gestalt/core/Trees.scala
@@ -18,6 +18,10 @@ trait Trees extends Params with TypeParams with
   type Cap >: Null
   implicit val cap: Cap = null
 
+  // An Unsafe capability is required to call the untyped Ident(name) and TypeIdent
+  // in order to achieve hygiene
+  type Unsafe
+
   // safety by construction -- implementation can have TypeTree = Tree
   type Tree     >: Null <: AnyRef
   type TypeTree >: Null <: Tree
@@ -144,7 +148,7 @@ trait Trees extends Params with TypeParams with
   // type trees
   def TypeIdent: TypeIdentImpl
   trait TypeIdentImpl {
-    def apply(name: String): TypeTree
+    def apply(name: String)(implicit unsafe: Unsafe): TypeTree
   }
 
   def TypeSelect: TypeSelectImpl
@@ -301,7 +305,7 @@ trait Trees extends Params with TypeParams with
     def Var(name: String): PatTree
     def Ascribe(name: String, tp: TypeTree): PatTree
     def Bind(name: String, expr: PatTree): PatTree
-    def Ident(name: String): PatTree = toolbox.Ident(name)
+    def Ident(name: String)(implicit unsafe: Unsafe): PatTree = toolbox.Ident(name)
     def Lit(value: Any): PatTree = toolbox.Lit(value)
     def Alt(trees: Seq[PatTree]): PatTree
     def Unapply(fun: TermTree, args: Seq[PatTree]): PatTree
@@ -346,7 +350,7 @@ trait Trees extends Params with TypeParams with
 
   def Ident: IdentImpl
   trait IdentImpl {
-    def apply(name: String): Ident
+    def apply(name: String)(implicit unsafe: Unsafe): Ident
     def apply(symbol: Symbol): tpd.Tree
     def unapply(tree: Tree): Option[String]
     def unapply(tree: tpd.Tree)(implicit c: Cap): Option[String]

--- a/src/main/scala/gestalt/core/Types.scala
+++ b/src/main/scala/gestalt/core/Types.scala
@@ -23,8 +23,8 @@ trait Types extends MethodTypes { this: Toolbox =>
     /** returning a type referring to a global value definition */
     def termRef(path: String): Type
 
-    /** does the type refer to a case class? */
-    def isCaseClass(tp: Type): Boolean
+    /** class symbol associated with the type */
+    def classSymbol(tp: Type): Option[Symbol]
 
     /** fields of a case class type -- only the ones declared in primary constructor */
     def caseFields(tp: Type): Seq[Denotation]

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -221,7 +221,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
 
   // types
   object TypeIdent extends TypeIdentImpl {
-    def apply(name: String): TypeTree = d.Ident(name.toTypeName).withPosition
+    def apply(name: String)(implicit c: Unsafe): TypeTree = d.Ident(name.toTypeName).withPosition
   }
 
   object TypeSelect extends TypeSelectImpl {
@@ -440,7 +440,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       d.Ident(name.toTermName).withPosition
 
     def Ascribe(name: String, tp: TypeTree): PatTree =
-      d.Typed(Ident(name), tp).withPosition
+      d.Typed(d.Ident(name.toTermName), tp).withPosition
 
     def Unapply(fun: TermTree, args: Seq[PatTree]): PatTree =
       d.Apply(fun, args.toList).withPosition
@@ -485,7 +485,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
   }
 
   object Ident extends IdentImpl {
-    def apply(name: String): Ident = d.Ident(name.toTermName).withPosition
+    def apply(name: String)(implicit c: Unsafe): Ident = d.Ident(name.toTermName).withPosition
     def unapply(tree: Tree): Option[String] = tree match {
       case c.Ident(name) if name.isTermName => Some(name.show)
       case _ => None

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -1094,8 +1094,13 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
     /** returning a type referring to a term definition */
     def termRef(path: String): Type = ctx.staticRef(path.toTermName, false).symbol.termRef
 
-    /** does the type refer to a case class? */
     def isCaseClass(tp: Type): Boolean = tp.classSymbol.is(Flags.Case)
+
+    /** class symbol associated with the type */
+    def classSymbol(tp: Type): Option[Symbol] = tp.classSymbol match {
+      case Symbols.NoSymbol => None
+      case cls      => Some(cls)
+    }
 
     /** val fields of a case class Type -- only the ones declared in primary constructor */
     def caseFields(tp: Type): Seq[Denotation] = {
@@ -1197,6 +1202,18 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
 
     /** type of a member with respect to a prefix */
     def asSeenFrom(mem: Symbol, prefix: Type): Type = mem.asSeenFrom(prefix).info
+
+    def isCase(sym: Symbol): Boolean = sym.is(Flags.Case)
+    def isTrait(sym: Symbol): Boolean = sym.is(Flags.Trait)
+    def isPrivate(sym: Symbol): Boolean = sym.is(Flags.Private)
+    def isProtected(sym: Symbol): Boolean = sym.is(Flags.Protected)
+    def isOverride(sym: Symbol): Boolean = sym.is(Flags.Override)
+    def isFinal(sym: Symbol): Boolean = sym.is(Flags.Final)
+    def isImplicit(sym: Symbol): Boolean = sym.is(Flags.Implicit)
+    def isLazy(sym: Symbol): Boolean = sym.is(Flags.Lazy)
+    def isSealed(sym: Symbol): Boolean = sym.is(Flags.Sealed)
+    def isAbstract(sym: Symbol): Boolean = sym.is(Flags.Abstract)
+    def isMutable(sym: Symbol): Boolean = sym.is(Flags.Mutable)
   }
 
   def ensureOwner(tree: tpd.Tree, owner: Symbol): tpd.Tree = {

--- a/src/main/scala/gestalt/options.scala
+++ b/src/main/scala/gestalt/options.scala
@@ -1,0 +1,5 @@
+package scala.gestalt
+
+object options {
+  implicit val unsafe: api.Unsafe = null
+}

--- a/src/main/scala/gestalt/quasiquotes/Quote.scala
+++ b/src/main/scala/gestalt/quasiquotes/Quote.scala
@@ -4,25 +4,17 @@ import scala.collection.immutable.Seq
 import scala.{meta => m}
 import scala.compat.Platform.EOL
 import scala.gestalt.api._
+import scala.gestalt.options.unsafe
 
 /** Lift scala.meta trees as trees */
 class Quote(args: List[Tree], isTerm: Boolean, enclosingTree: Tree) {
   type Quasi = m.internal.ast.Quasi
 
   // lifted trees
-  lazy val scalaNil       = selectFullPath("scala.Nil")
-  lazy val scalaList      = selectFullPath("scala.List")
-  lazy val scalaSome      = selectFullPath("scala.Some")
-  lazy val scalaNone      = selectFullPath("scala.None")
-  lazy val root           = Ident("_root_")
-
-  private def selectFullPath(path: String): TermTree = {
-    val parts = path.split('.')
-
-    parts.foldLeft[TermTree](root) { (prefix, name) =>
-      prefix.select(name)
-    }
-  }
+  lazy val scalaNil       = root.select("scala.Nil")
+  lazy val scalaList      = root.select("scala.List")
+  lazy val scalaSome      = root.select("scala.Some")
+  lazy val scalaNone      = root.select("scala.None")
 
   private def selectPath(path: String): TermTree = {
     val parts = path.split('.')
@@ -244,7 +236,7 @@ class Quote(args: List[Tree], isTerm: Boolean, enclosingTree: Tree) {
       case _ =>
         if (!isTerm) {
           error("Match modifiers in syntax is problematic and not supported. Match the modifiers with a variable instead or $_ to ignore them.", enclosingTree.pos)
-          return Ident("_")
+          return selectPath("Pat.Var").appliedTo(Lit("_"))
         }
     }
 


### PR DESCRIPTION
This is a simple while practical solution to the hygiene problem: it still allows programmers to do the hack if `scala.gestalt.options.unsafe` is imported. By default, only fully-qualified name or symbol-based name is supported.

When scala supports literal types, we can do better with the API:

```Scala
      def Ident(name: "_root_"): Tree
      def Ident(name: "scala")(implcit dummy: C): Tree
```