### PR TITLE
add Infer as API

### DIFF
--- a/macros/src/main/scala/gestalt/macros/Monadless.scala
+++ b/macros/src/main/scala/gestalt/macros/Monadless.scala
@@ -220,7 +220,7 @@ object Transformer {
             case unlifts =>
               val (trees, dummies, types) = unlifts.unzip3
               val list = fresh("list")
-              val scalaList = Ident(Type.termRef("scala.collection.immutable.List").symbol.get).select("apply")
+              val scalaList = Ident(Type.termRef("scala.collection.immutable.List.apply"))
               val seqLiteral = SeqLiteral(trees, trees.head.tpe.widen)
               val arg = scalaList.appliedToTypes(trees.head.tpe.widen.toTree).appliedTo(seqLiteral)
               val collect = Resolve.collect(tree.pos).appliedToTypes(types.head.tpe.toTree).appliedTo(arg)

--- a/src/main/scala/gestalt/api.scala
+++ b/src/main/scala/gestalt/api.scala
@@ -433,6 +433,11 @@ object api extends Toolbox {
     def instantiate(params: List[Type]): Type = MethodType.instantiate(tp)(params)
   }
 
+  implicit class TermRefOps(tp: TermRef) {
+    def symbol: Symbol    = denot.symbol
+    def denot: Denotation = Type.denot(tp).get
+  }
+
   /**--------------------- Symbols ---------------------------------*/
   def Symbol         = toolbox.get.Symbol.asInstanceOf[SymbolImpl]
 

--- a/src/main/scala/gestalt/core/Trees.scala
+++ b/src/main/scala/gestalt/core/Trees.scala
@@ -362,6 +362,7 @@ trait Trees extends Params with TypeParams with
   trait IdentImpl {
     def apply(name: String)(implicit unsafe: Unsafe): Ident
     def apply(symbol: Symbol): tpd.Tree
+    def apply(tp: TermRef)(implicit c: Cap): tpd.Tree = Ident(Denotation.symbol(Type.denot(tp).get))
     def unapply(tree: Tree): Option[String]
     def unapply(tree: tpd.Tree)(implicit c: Cap): Option[String]
   }

--- a/src/main/scala/gestalt/core/Types.scala
+++ b/src/main/scala/gestalt/core/Types.scala
@@ -2,6 +2,8 @@ package scala.gestalt.core
 
 trait Types extends MethodTypes { this: Toolbox =>
   type Type >: Null <: AnyRef
+  type TermRef <: Type
+  type TypeRef <: Type
 
   def Type: TypeImpl
   trait TypeImpl {
@@ -18,10 +20,10 @@ trait Types extends MethodTypes { this: Toolbox =>
     def lub(tp1: Type, tp2: Type): Type
 
     /** returning a type referring to a global type definition */
-    def typeRef(path: String): Type
+    def typeRef(path: String): TypeRef
 
     /** returning a type referring to a global value definition */
-    def termRef(path: String): Type
+    def termRef(path: String): TermRef
 
     /** class symbol associated with the type */
     def classSymbol(tp: Type): Option[Symbol]
@@ -63,6 +65,9 @@ trait Types extends MethodTypes { this: Toolbox =>
 
     /** Turn a type into a typed tree */
     def toTree(tp: Type): tpd.Tree
+
+    /** Infer an implicit instance of the given type */
+    def infer(tp: Type): Option[tpd.Tree]
   }
 
 


### PR DESCRIPTION
The `infer` API is needed for the JsonMacro refactoring.