### PR TITLE
Def macros: Removed PathType

### DIFF
--- a/macros/src/main/scala/gestalt/macros/Optional.scala
+++ b/macros/src/main/scala/gestalt/macros/Optional.scala
@@ -28,14 +28,11 @@ final class Optional[+A >: Null](val value: A) extends AnyVal {
         Select(tempIdent, "value")
     }
 
-    {
-      import scala.gestalt.options.unsafe
-      q"""
+    q"""
        $tempValDef
-       if ($tempIdent.isEmpty) new Optional(null)
-       else new Optional(${newBody.wrap})
+       if ($tempIdent.isEmpty) new _empty_.Optional(null)
+       else new _empty_.Optional(${newBody.wrap})
      """
-    }
   }
 
   override def toString = if (isEmpty) "<empty>" else s"$value"

--- a/macros/src/main/scala/gestalt/macros/Optional.scala
+++ b/macros/src/main/scala/gestalt/macros/Optional.scala
@@ -28,11 +28,14 @@ final class Optional[+A >: Null](val value: A) extends AnyVal {
         Select(tempIdent, "value")
     }
 
-    q"""
+    {
+      import scala.gestalt.options.unsafe
+      q"""
        $tempValDef
        if ($tempIdent.isEmpty) new Optional(null)
-       else new Optional($newBody)
+       else new Optional(${newBody.wrap})
      """
+    }
   }
 
   override def toString = if (isEmpty) "<empty>" else s"$value"

--- a/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
+++ b/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
@@ -44,7 +44,7 @@ class Quasiquotes extends StaticAnnotation {
     test("new") {
       val file = Lit("path")
       val expr = q"new xsd($file)"
-      assert(expr.toString === NewInstance(None, "xsd", Nil, (Lit("path") :: Nil) :: Nil).toString)
+      assert(expr.toString === NewInstance(TypeIdent("xsd"), (Lit("path") :: Nil) :: Nil).toString)
     }
 
     test("new 2") {

--- a/src/main/scala/gestalt/api.scala
+++ b/src/main/scala/gestalt/api.scala
@@ -51,6 +51,7 @@ object api extends Toolbox {
    *  `scala.gestalt.options.unsafe` is imported.
    */
   def root: TermTree = Ident("_root_")
+  def empty: TermTree = Ident("_empty_")
 
   def Ident(name: "_root_"): TermTree = {
     import options.unsafe
@@ -65,6 +66,11 @@ object api extends Toolbox {
   def Ident(name: "java")(implicit dummy: Dummy1): TermTree = {
     import options.unsafe
     Ident.apply("java")
+  }
+
+  def Ident(name: "_empty_")(implicit dummy: Dummy2): TermTree = {
+    import options.unsafe
+    Ident.apply("<empty>")
   }
 
   /**------------------------------------------------*/

--- a/src/main/scala/gestalt/api.scala
+++ b/src/main/scala/gestalt/api.scala
@@ -83,7 +83,6 @@ object api extends Toolbox {
   // type trees
   def TypeIdent      = toolbox.TypeIdent.asInstanceOf[TypeIdentImpl]
   def TypeSelect     = toolbox.TypeSelect.asInstanceOf[TypeSelectImpl]
-  def PathType       = toolbox.PathType.asInstanceOf[PathTypeImpl]
   def TypeSingleton  = toolbox.TypeSingleton.asInstanceOf[TypeSingletonImpl]
   def TypeApply      = toolbox.TypeApply.asInstanceOf[TypeApplyImpl]
   def TypeInfix      = toolbox.TypeInfix.asInstanceOf[TypeInfixImpl]

--- a/src/main/scala/gestalt/core/Toolbox.scala
+++ b/src/main/scala/gestalt/core/Toolbox.scala
@@ -9,6 +9,9 @@ trait Toolbox extends Trees with Types with Denotations with Symbols with TypeTa
   trait Dummy1
   implicit val dummy1: Dummy1 = null
 
+  trait Dummy2
+  implicit val dummy2: Dummy2 = null
+
   // An Unsafe capability is required to call the untyped Ident(name) and TypeIdent
   // in order to achieve hygiene
   type Unsafe

--- a/src/main/scala/gestalt/core/Trees.scala
+++ b/src/main/scala/gestalt/core/Trees.scala
@@ -124,11 +124,9 @@ trait Trees extends Params with TypeParams with
 
   def NewInstance: NewInstanceImpl
   trait NewInstanceImpl {
-    def apply(qual: Option[Tree], name: String, targs: List[TypeTree], argss: List[List[TermTree]]): TermTree
-    def apply(tpe: TypeTree, argss: List[List[TermTree]]): TermTree = {
-      val Trees.this.PathType(qual, name, targs) = tpe
-      apply(qual, name, targs, argss)
-    }
+    def apply(typeTree: TypeTree, argss: List[List[TermTree]]): TermTree
+
+    def apply(tp: Type, argss: List[List[tpd.Tree]])(implicit cap: Dummy): tpd.Tree
   }
 
   def SecondaryCtor: SecondaryCtorImpl
@@ -151,12 +149,6 @@ trait Trees extends Params with TypeParams with
   def TypeSelect: TypeSelectImpl
   trait TypeSelectImpl {
     def apply(qual: Tree, name: String): TypeTree
-  }
-
-  def PathType: PathTypeImpl
-  trait PathTypeImpl {
-    def apply(qual: Option[Tree], name: String, targs: List[TypeTree]): TypeTree
-    def unapply(tpe: TypeTree) : Option[(Option[Tree], String, List[TypeTree])]
   }
 
   def TypeSingleton: TypeSingletonImpl

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -202,8 +202,15 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
 
   // new qual.T[A, B](x, y)(z)
   object NewInstance extends NewInstanceImpl {
-    def apply(qual: Option[Tree], name: String, targs: List[TypeTree], argss: List[List[TermTree]]): TermTree = {
-      ApplySeq(d.Select(d.New(PathType(qual, name, targs)), nme.CONSTRUCTOR), argss).withPosition
+    def apply(typeTree: TypeTree, argss: List[List[TermTree]]): TermTree = {
+      ApplySeq(d.Select(d.New(typeTree), nme.CONSTRUCTOR), argss).withPosition
+    }
+
+    def apply(tp: Type, argss: List[List[tpd.Tree]])(implicit cap: Dummy): tpd.Tree = {
+      argss match {
+        case head :: tail => tail.foldLeft[tpd.Tree](t.New(tp, head)) { (acc, args) => Apply(acc, args) }
+        case Nil => t.New(tp)
+      }
     }
   }
 
@@ -222,28 +229,6 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
 
   object TypeSelect extends TypeSelectImpl {
     def apply(qual: Tree, name: String): TypeTree = d.Select(qual, name.toTypeName).withPosition
-  }
-
-  object PathType extends PathTypeImpl {
-    def apply(qual: Option[Tree], name: String, targs: List[TypeTree]) = {
-      val select = if (qual.isEmpty) d.Ident(name.toTypeName) else d.Select(qual.get, name.toTypeName)
-      if (targs.isEmpty) select else TypeApply(select, targs)
-    }
-    def unapply(tpe: TypeTree) = {
-      val withoutTypedSplice = tpe match {
-        case TypedSplice(tree) => tree
-        case _ => tpe
-      }
-      val (select, targs) = withoutTypedSplice match {
-        case c.AppliedTypeTree(tpe, targs) => tpe -> targs
-        case other => other -> Nil
-      }
-      select match {
-        case c.Select(qual, name) if name.isTypeName => Some((Some(qual), name.show, targs))
-        case c.Ident(name) if name.isTypeName => Some((None, name.show, targs))
-        case _ => None
-      }
-    }
   }
 
   object TypeSingleton extends TypeSingletonImpl {

--- a/src/main/scala/gestalt/quasiquotes/Quote.scala
+++ b/src/main/scala/gestalt/quasiquotes/Quote.scala
@@ -160,7 +160,8 @@ class Quote(args: List[Tree], isTerm: Boolean, enclosingTree: Tree) {
 
   def liftNewInstance(tree: m.Tree): TermTree = {
     val Argss(TypeArguments(Qualifier(m.Ctor.Ref.Name(name), qualOpt), targs), argss) = tree
-    Ident("NewInstance").appliedTo(liftOpt(qualOpt), Lit(name), liftSeq(targs), liftSeqSeq(argss))
+    val tp = composeType(qualOpt, name, targs)
+    Ident("NewInstance").appliedTo(tp, liftSeqSeq(argss))
   }
 
   /** {{{(trees: Seq[Tree[Tree[A]]]) => Tree[Seq[Tree[A]]]}}} */


### PR DESCRIPTION
1. Added a `NewInstance` constructor that respects macro hygiene (safe) as per @liufengyun 's example.
2. Made the syntactic way of calling `NewInstance` unsafe. Even if you provide a qualifier, it may not be fully qualified, i.e., does not start from `_root_`.
3. Added an unsafe `NewInstance` constructor similar to the safe one. 
```scala
NewInstance(tp: Type, argss: List[List[TermTree]])(implicit unsafe: Unsafe): TermTree
```
4. Migrated the existing uses of the old api.