### PR TITLE
refactor design of InitCall

### DIFF
--- a/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
+++ b/macros/src/main/scala/gestalt/macros/Quasiquotes.scala
@@ -50,7 +50,7 @@ class Quasiquotes extends StaticAnnotation {
     test("new 2") {
       val expr = q"new X with T { def m = 42 }"
       val anonymClass = NewAnonymClass(
-        InitCall(None, "X", Nil, Nil) :: InitCall(None, "T", Nil, Nil) :: Nil,
+        InitCall(TypeIdent("X"), Nil) :: InitCall(TypeIdent("T"), Nil) :: Nil,
         None,
         DefDef(emptyMods, "m", Nil, Nil, None, Lit(42)) :: Nil
       )

--- a/src/main/scala/gestalt/api.scala
+++ b/src/main/scala/gestalt/api.scala
@@ -57,9 +57,14 @@ object api extends Toolbox {
     Ident.apply("_root_")
   }
 
-  def Ident(name: "scala")(implicit dummy: Cap): TermTree = {
+  def Ident(name: "scala")(implicit dummy: Dummy): TermTree = {
     import options.unsafe
     Ident.apply("scala")
+  }
+
+  def Ident(name: "java")(implicit dummy: Dummy1): TermTree = {
+    import options.unsafe
+    Ident.apply("java")
   }
 
   /**------------------------------------------------*/
@@ -247,7 +252,7 @@ object api extends Toolbox {
 
   object OfValDef {
     def unapply(tree: Tree): Option[ValDef] = ValDef.get(tree)
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[tpd.ValDef] = ValDef.get(tree)(c)
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[tpd.ValDef] = ValDef.get(tree)(c)
   }
 
   /**--------------------- ValDecls ---------------------------------*/
@@ -396,7 +401,7 @@ object api extends Toolbox {
       Some(recur(Nil, call))
     }
 
-    def unapply(call: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, List[List[tpd.Tree]])] =
+    def unapply(call: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, List[List[tpd.Tree]])] =
       unapply(call.asInstanceOf[TermTree]).asInstanceOf[Option[(tpd.Tree, List[List[tpd.Tree]])]]
   }
 

--- a/src/main/scala/gestalt/core/Toolbox.scala
+++ b/src/main/scala/gestalt/core/Toolbox.scala
@@ -3,6 +3,15 @@ package scala.gestalt.core
 case class Location(fileName: String, line: Int, column: Int)
 
 trait Toolbox extends Trees with Types with Denotations with Symbols with TypeTags {
+  trait Dummy
+  implicit val dummy: Dummy = null
+
+  trait Dummy1
+  implicit val dummy1: Dummy1 = null
+
+  // An Unsafe capability is required to call the untyped Ident(name) and TypeIdent
+  // in order to achieve hygiene
+  type Unsafe
 
   /** get the location where the def macro is used */
   def location: Location

--- a/src/main/scala/gestalt/core/Trees.scala
+++ b/src/main/scala/gestalt/core/Trees.scala
@@ -15,17 +15,7 @@ trait Trees extends Params with TypeParams with
   ValDefs with ValDecls with DefDefs with DefDecls with
   Classes with Traits with Objects with Positions { toolbox: Toolbox =>
 
-  trait Dummy
-  implicit val dummy: Dummy = null
-
-  trait Dummy1
-  implicit val dummy1: Dummy1 = null
-
-  // An Unsafe capability is required to call the untyped Ident(name) and TypeIdent
-  // in order to achieve hygiene
-  type Unsafe
-
-  // safety by construction -- implementation can have TypeTree = Tree
+ // safety by construction -- implementation can have TypeTree = Tree
   type Tree     >: Null <: AnyRef
   type TypeTree >: Null <: Tree
   type TermTree >: Null <: Tree

--- a/src/main/scala/gestalt/core/Trees.scala
+++ b/src/main/scala/gestalt/core/Trees.scala
@@ -7,7 +7,7 @@ trait Positions { this: Toolbox =>
   def Pos: PosImpl
   trait PosImpl {
     def pos(tree: Tree): Pos
-    def pos(tree: tpd.Tree)(implicit c: Cap): Pos
+    def pos(tree: tpd.Tree)(implicit c: Dummy): Pos
   }
 }
 
@@ -15,8 +15,11 @@ trait Trees extends Params with TypeParams with
   ValDefs with ValDecls with DefDefs with DefDecls with
   Classes with Traits with Objects with Positions { toolbox: Toolbox =>
 
-  type Cap >: Null
-  implicit val cap: Cap = null
+  trait Dummy
+  implicit val dummy: Dummy = null
+
+  trait Dummy1
+  implicit val dummy1: Dummy1 = null
 
   // An Unsafe capability is required to call the untyped Ident(name) and TypeIdent
   // in order to achieve hygiene
@@ -126,7 +129,7 @@ trait Trees extends Params with TypeParams with
   // extends qual.T[A, B](x, y)(z)
   def InitCall: InitCallImpl
   trait InitCallImpl {
-    def apply(qual: Option[Tree], name: String, targs: List[TypeTree], argss: List[List[TermTree]]): InitCall
+    def apply(tpe: TypeTree, argss: List[List[TermTree]]): InitCall
   }
 
   def NewInstance: NewInstanceImpl
@@ -263,8 +266,8 @@ trait Trees extends Params with TypeParams with
     def apply(cond: TermTree, thenp: TermTree, elsep: Option[TermTree]): TermTree
     def unapply(tree: Tree): Option[(TermTree, TermTree, Option[TermTree])]
 
-    def apply(cond: tpd.Tree, thenp: tpd.Tree, elsep: tpd.Tree)(implicit cap: Cap): tpd.Tree
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, tpd.Tree, tpd.Tree)]
+    def apply(cond: tpd.Tree, thenp: tpd.Tree, elsep: tpd.Tree)(implicit cap: Dummy): tpd.Tree
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, tpd.Tree, tpd.Tree)]
   }
 
   def Try: TryImpl
@@ -338,15 +341,15 @@ trait Trees extends Params with TypeParams with
   trait LitImpl {
     def apply(value: Any): Lit
     def unapply(tree: Tree): Option[Any]
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[Any]
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[Any]
   }
 
   def Apply: ApplyImpl
   trait ApplyImpl {
     def apply(fun: TermTree, args: List[TermTree]): TermTree
     def unapply(tree: Tree): Option[(TermTree, List[TermTree])]
-    def apply(fun: tpd.Tree, args: List[tpd.Tree])(implicit c: Cap): tpd.Tree
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, List[tpd.Tree])]
+    def apply(fun: tpd.Tree, args: List[tpd.Tree])(implicit c: Dummy): tpd.Tree
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, List[tpd.Tree])]
   }
 
   def ApplyType: ApplyTypeImpl
@@ -354,24 +357,24 @@ trait Trees extends Params with TypeParams with
     def apply(fun: TermTree, args: List[TypeTree]): TermTree
     def unapply(tree: Tree): Option[(TermTree, List[TypeTree])]
 
-    def apply(fun: tpd.Tree, args: List[tpd.Tree])(implicit c: Cap): tpd.Tree
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, List[tpd.Tree])]
+    def apply(fun: tpd.Tree, args: List[tpd.Tree])(implicit c: Dummy): tpd.Tree
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, List[tpd.Tree])]
   }
 
   def Ident: IdentImpl
   trait IdentImpl {
     def apply(name: String)(implicit unsafe: Unsafe): Ident
     def apply(symbol: Symbol): tpd.Tree
-    def apply(tp: TermRef)(implicit c: Cap): tpd.Tree = Ident(Denotation.symbol(Type.denot(tp).get))
+    def apply(tp: TermRef)(implicit c: Dummy): tpd.Tree = Ident(Denotation.symbol(Type.denot(tp).get))
     def unapply(tree: Tree): Option[String]
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[String]
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[String]
   }
 
   def This: ThisImpl
   trait ThisImpl {
     def apply(qual: String): TermTree
     def unapply(tree: Tree): Option[String]
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[String]
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[String]
   }
 
   def Super: SuperImpl
@@ -384,8 +387,8 @@ trait Trees extends Params with TypeParams with
     def apply(qual: TermTree, name: String): TermTree
     def unapply(tree: Tree): Option[(TermTree, String)]
 
-    def apply(qual: tpd.Tree, name: String)(implicit c: Cap): tpd.Tree
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, String)]
+    def apply(qual: tpd.Tree, name: String)(implicit c: Dummy): tpd.Tree
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, String)]
   }
 
   def Ascribe: AscribeImpl
@@ -393,15 +396,15 @@ trait Trees extends Params with TypeParams with
     def apply(expr: TermTree, tpe: TypeTree): TermTree
     def unapply(tree: Tree): Option[(TermTree, TypeTree)]
 
-    def apply(expr: tpd.Tree, tpe: tpd.Tree)(implicit c: Cap): tpd.Tree
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, tpd.Tree)]
+    def apply(expr: tpd.Tree, tpe: tpd.Tree)(implicit c: Dummy): tpd.Tree
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, tpd.Tree)]
   }
 
   def Assign: AssignImpl
   trait AssignImpl {
     def apply(lhs: TermTree, rhs: TermTree): TermTree
     def unapply(tree: Tree): Option[(TermTree, TermTree)]
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, tpd.Tree)]
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, tpd.Tree)]
   }
 
   def Update: UpdateImpl
@@ -414,7 +417,7 @@ trait Trees extends Params with TypeParams with
     def apply(expr: TermTree): TermTree
     def apply: TermTree
     def unapply(tree: Tree): Option[Option[TermTree]]
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[tpd.Tree]
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[tpd.Tree]
   }
 
   def Block: BlockImpl
@@ -422,8 +425,8 @@ trait Trees extends Params with TypeParams with
     def apply(stats: List[Tree]): TermTree
     def unapply(tree: Tree): Option[List[Tree]]
 
-    def apply(stats: List[tpd.Tree], expr: tpd.Tree)(implicit c: Cap): tpd.Tree
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(List[tpd.Tree], tpd.Tree)]
+    def apply(stats: List[tpd.Tree], expr: tpd.Tree)(implicit c: Dummy): tpd.Tree
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(List[tpd.Tree], tpd.Tree)]
   }
 
   def PartialFunction: PartialFunctionImpl
@@ -436,21 +439,21 @@ trait Trees extends Params with TypeParams with
   trait MatchImpl {
     def apply(expr: TermTree, cases: List[Tree]): TermTree
     def unapply(tree: Tree): Option[(TermTree, List[Tree])]
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, List[tpd.Tree])]
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, List[tpd.Tree])]
   }
 
   def Case: CaseImpl
   trait CaseImpl {
     def apply(pat: PatTree, cond: Option[TermTree], body: TermTree): Tree
     def unapply(tree: Tree): Option[(TermTree, Option[TermTree], TermTree)]
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, Option[tpd.Tree], tpd.Tree)]
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, Option[tpd.Tree], tpd.Tree)]
   }
 
   def Tuple: TupleImpl
   trait TupleImpl {
     def apply(args: List[TermTree]): TermTree
     def unapply(tree: Tree): Option[List[TermTree]]
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[List[tpd.Tree]]
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[List[tpd.Tree]]
   }
 
   def Interpolate: InterpolateImpl
@@ -509,13 +512,13 @@ trait ValDefs { this: Toolbox =>
     def unapply(tree: Tree): Option[(String, Option[TypeTree], TermTree)]
 
     def apply(name: String, rhs: tpd.Tree): tpd.ValDef
-    def symbol(tree: tpd.ValDef)(implicit c: Cap): Symbol
-    def name(tree: tpd.ValDef)(implicit c: Cap): String
-    def rhs(tree: tpd.ValDef)(implicit c: Cap): TermTree
-    def tptOpt(tree: tpd.ValDef)(implicit c: Cap): Option[TypeTree]
-    def copyRhs(tree: tpd.ValDef)(rhs: tpd.Tree)(implicit c: Cap): tpd.ValDef
-    def get(tree: tpd.Tree)(implicit c: Cap): Option[tpd.ValDef]
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(String, Option[TypeTree], TermTree)]
+    def symbol(tree: tpd.ValDef)(implicit c: Dummy): Symbol
+    def name(tree: tpd.ValDef)(implicit c: Dummy): String
+    def rhs(tree: tpd.ValDef)(implicit c: Dummy): TermTree
+    def tptOpt(tree: tpd.ValDef)(implicit c: Dummy): Option[TypeTree]
+    def copyRhs(tree: tpd.ValDef)(rhs: tpd.Tree)(implicit c: Dummy): tpd.ValDef
+    def get(tree: tpd.Tree)(implicit c: Dummy): Option[tpd.ValDef]
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(String, Option[TypeTree], TermTree)]
   }
 }
 
@@ -580,9 +583,9 @@ trait Params { self : Toolbox =>
     def defaultOpt(tree: Param): Option[TermTree]
     def copyMods(tree: Param)(mods: Mods): Param
 
-    def symbol(tree: tpd.Param)(implicit c: Cap): Symbol
-    def name(tree: tpd.Param)(implicit c: Cap): String
-    def tpt(tree: tpd.Param)(implicit c: Cap): tpd.Tree
+    def symbol(tree: tpd.Param)(implicit c: Dummy): Symbol
+    def name(tree: tpd.Param)(implicit c: Dummy): String
+    def tpt(tree: tpd.Param)(implicit c: Dummy): tpd.Tree
   }
 }
 

--- a/src/main/scala/gestalt/dotty/DottyToolbox.scala
+++ b/src/main/scala/gestalt/dotty/DottyToolbox.scala
@@ -48,7 +48,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
   object Pos extends PosImpl {
     def pos(tree: Tree): Pos = tree.pos
 
-    def pos(tree: tpd.Tree)(implicit c: Cap): Pos = tree.pos
+    def pos(tree: tpd.Tree)(implicit c: Dummy): Pos = tree.pos
   }
 
   /*------------------------------ modifiers ------------------------------*/
@@ -195,10 +195,8 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
 
   // qual.T[A, B](x, y)(z)
   object InitCall extends InitCallImpl {
-    def apply(qual: Option[Tree], name: String, targs: List[TypeTree], argss: List[List[TermTree]]): InitCall = {
-      val select = if (qual.isEmpty) d.Ident(name.toTypeName) else d.Select(qual.get, name.toTypeName)
-      val fun = if (targs.isEmpty) select else TypeApply(select, targs)
-      ApplySeq(fun, argss).withPosition
+    def apply(tpe: TypeTree, argss: List[List[TermTree]]): InitCall = {
+      ApplySeq(tpe, argss).withPosition
     }
   }
 
@@ -364,7 +362,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case c.Return(expr, _) => Some(if (expr.isEmpty) None else Some(expr))
       case _ => None
     }
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[tpd.Tree] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[tpd.Tree] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[tpd.Tree]]
   }
 
@@ -382,10 +380,10 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => None
     }
 
-    def apply(cond: tpd.Tree, thenp: tpd.Tree, elsep: tpd.Tree)(implicit c: Cap): tpd.Tree =
+    def apply(cond: tpd.Tree, thenp: tpd.Tree, elsep: tpd.Tree)(implicit c: Dummy): tpd.Tree =
       t.If(cond, thenp, elsep)
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, tpd.Tree, tpd.Tree)] = tree match {
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, tpd.Tree, tpd.Tree)] = tree match {
       case tree: t.If => Some(tree.cond, tree.thenp, tree.elsep)
       case _          => None
     }
@@ -500,7 +498,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => None
     }
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[Any] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[Any] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[Any]]
   }
 
@@ -512,7 +510,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
     }
 
     def apply(symbol: Symbol): tpd.Tree = t.ref(symbol)
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[String] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[String] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[String]]
   }
 
@@ -523,7 +521,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => None
     }
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[String] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[String] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[String]]
   }
 
@@ -534,11 +532,11 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => None
     }
 
-    def apply(qual: tpd.Tree, name: String)(implicit c: Cap): tpd.Tree =
+    def apply(qual: tpd.Tree, name: String)(implicit c: Dummy): tpd.Tree =
       t.Select(qual, name.toTermName)
       // t.Select(qual.withTypeUnchecked(qual.tpe.widen), name.toTermName)
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, String)] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, String)] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[(tpd.Tree, String)]]
   }
 
@@ -551,9 +549,9 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => None
     }
 
-    def apply(fun: tpd.Tree, args: List[tpd.Tree])(implicit c: Cap): tpd.Tree = t.Apply(fun, args)
+    def apply(fun: tpd.Tree, args: List[tpd.Tree])(implicit c: Dummy): tpd.Tree = t.Apply(fun, args)
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, List[tpd.Tree])] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, List[tpd.Tree])] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[(tpd.Tree, List[tpd.Tree])]]
   }
 
@@ -565,10 +563,10 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => None
     }
 
-    def apply(expr: tpd.Tree, tpe: tpd.Tree)(implicit c: Cap): tpd.Tree =
+    def apply(expr: tpd.Tree, tpe: tpd.Tree)(implicit c: Dummy): tpd.Tree =
       t.Typed(expr, tpe)
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, tpd.Tree)] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, tpd.Tree)] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[(tpd.Tree, tpd.Tree)]]
   }
 
@@ -580,7 +578,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => None
     }
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, tpd.Tree)] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, tpd.Tree)] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[(tpd.Tree, tpd.Tree)]]
   }
 
@@ -623,10 +621,10 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => None
     }
 
-    def apply(stats: List[tpd.Tree], expr: tpd.Tree)(implicit c: Cap): tpd.Tree =
+    def apply(stats: List[tpd.Tree], expr: tpd.Tree)(implicit c: Dummy): tpd.Tree =
       t.Block(stats, expr)
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(List[tpd.Tree], tpd.Tree)] = tree match {
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(List[tpd.Tree], tpd.Tree)] = tree match {
       case block: t.Block => Some((block.stats, block.expr))
       case _ => None
     }
@@ -641,7 +639,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => None
     }
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, List[tpd.Tree])] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, List[tpd.Tree])] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[(tpd.Tree, List[tpd.Tree])]]
   }
 
@@ -656,7 +654,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => None
     }
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, Option[tpd.Tree], tpd.Tree)] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, Option[tpd.Tree], tpd.Tree)] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[(tpd.Tree, Option[tpd.Tree], tpd.Tree)]]
   }
 
@@ -677,7 +675,7 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => None
     }
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[List[tpd.Tree]] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[List[tpd.Tree]] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[List[tpd.Tree]]]
   }
 
@@ -701,10 +699,10 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       case _ => Some((tree, Nil))
     }
 
-    def apply(fun: tpd.Tree, args: List[tpd.Tree])(implicit c: Cap): tpd.Tree =
+    def apply(fun: tpd.Tree, args: List[tpd.Tree])(implicit c: Dummy): tpd.Tree =
       t.TypeApply(fun, args)
 
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(tpd.Tree, List[tpd.Tree])] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(tpd.Tree, List[tpd.Tree])] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[(tpd.Tree, List[tpd.Tree])]]
   }
 
@@ -869,9 +867,9 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
     def defaultOpt(tree: Param): Option[TermTree] = if (tree.forceIfLazy == d.EmptyTree) None else Some(tree.forceIfLazy)
     def copyMods(tree: Param)(mods: Mods): Param = tree.withMods(mods)
 
-    def symbol(tree: tpd.Param)(implicit c: Cap): Symbol = tree.symbol
-    def name(tree: tpd.Param)(implicit c: Cap): String = tree.name.show
-    def tpt(tree: tpd.Param)(implicit c: Cap): t.Tree = tree.tpt
+    def symbol(tree: tpd.Param)(implicit c: Dummy): Symbol = tree.symbol
+    def name(tree: tpd.Param)(implicit c: Dummy): String = tree.name.show
+    def tpt(tree: tpd.Param)(implicit c: Dummy): t.Tree = tree.tpt
   }
 
   object TypeParam extends TypeParamImpl {
@@ -922,14 +920,14 @@ class Toolbox(enclosingPosition: Position)(implicit ctx: Context) extends Tbox {
       t.ValDef(vsym, rhs)
     }
 
-    def symbol(tree: tpd.ValDef)(implicit c: Cap): Symbol = tree.symbol
-    def name(tree: tpd.ValDef)(implicit c: Cap): String = tree.name.show
-    def rhs(tree: tpd.ValDef)(implicit c: Cap): TermTree = tree.forceIfLazy
-    def tptOpt(tree: tpd.ValDef)(implicit c: Cap): Option[TypeTree] = Some(tree.tpt)
-    def copyRhs(tree: tpd.ValDef)(rhs: tpd.Tree)(implicit c: Cap): tpd.ValDef = t.cpy.ValDef(tree)(rhs = rhs)
-    def get(tree: tpd.Tree)(implicit c: Cap): Option[tpd.ValDef] =
+    def symbol(tree: tpd.ValDef)(implicit c: Dummy): Symbol = tree.symbol
+    def name(tree: tpd.ValDef)(implicit c: Dummy): String = tree.name.show
+    def rhs(tree: tpd.ValDef)(implicit c: Dummy): TermTree = tree.forceIfLazy
+    def tptOpt(tree: tpd.ValDef)(implicit c: Dummy): Option[TypeTree] = Some(tree.tpt)
+    def copyRhs(tree: tpd.ValDef)(rhs: tpd.Tree)(implicit c: Dummy): tpd.ValDef = t.cpy.ValDef(tree)(rhs = rhs)
+    def get(tree: tpd.Tree)(implicit c: Dummy): Option[tpd.ValDef] =
       get(tree.asInstanceOf[Tree]).asInstanceOf[Option[tpd.ValDef]]
-    def unapply(tree: tpd.Tree)(implicit c: Cap): Option[(String, Option[TypeTree], TermTree)] =
+    def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[(String, Option[TypeTree], TermTree)] =
       unapply(tree.asInstanceOf[Tree]).asInstanceOf[Option[(String, Option[TypeTree], TermTree)]]
   }
 


### PR DESCRIPTION
@valdisxp1 I did the refactoring for `InitCall`. It will be much easier for you to refactor `NewInstance` based on this PR.


The most important motivation for making `qual`, `name`, `targs` explicit
in the constructor is to make the extractor more friendly. The
consideration for semantic difference is secondary.

 I'd like to abandon the original design due to following reasons:

- inspecting syntactic structure of New expression is useless, only  crappy macros do that
- even if we merge `qual`, `name` and `targs`, it's still not difficult to address
  potential semantic difference in compiler implementation.
- following code is valid in Scala, which implies the semantic consideration is not well founded.

```Scala
type A = Some[Int]
new A(3)
```