### PR TITLE
test to show hygiene for user-code

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -208,3 +208,12 @@ object Whitebox {
     q"List(${x.wrap})"
   }
 }
+
+object Hygiene {
+  def f(x: Int): Int = meta {
+    q"""
+    val x = 4
+    $x
+    """
+  }
+}

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -216,4 +216,9 @@ class DefMacroTest extends TestSuite {
     val x = Whitebox.gimmelist(2)
     1 :: x
   }
+
+  test("hygiene") {
+    val x = 5
+    assert(Hygiene.f(x) == 5)
+  }
 }


### PR DESCRIPTION
The separation of typed trees and untyped trees also protects user-code from being polluted.