### PR TITLE
fix owner problem in typed transform

### DIFF
--- a/macros/src/main/scala/gestalt/macros/DefMacros.scala
+++ b/macros/src/main/scala/gestalt/macros/DefMacros.scala
@@ -217,3 +217,18 @@ object Hygiene {
     """
   }
 }
+
+object Transform {
+  def log(x: Int)(f: Int => Int): Int = meta {
+    val newfun = f.transform {
+      case call @ ApplySeq(f, args) if args.size > 0 =>
+        val name = f.symbol.get.name
+        val print = Ident(Type.termRef("scala.Predef")).select("print").appliedTo(Lit.typed(s"calling $name\n"))
+        val vdef = ValDef("temp", call)
+        val res = Ident(vdef.symbol)
+        Block(print :: vdef :: Nil, res)
+    }
+
+    newfun.select("apply").appliedTo(x)
+  }
+}

--- a/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
+++ b/macros/src/test/scala/gestalt/macros/DefMacroTest.scala
@@ -221,4 +221,12 @@ class DefMacroTest extends TestSuite {
     val x = 5
     assert(Hygiene.f(x) == 5)
   }
+
+  test("transform with owner change") {
+    val res = Transform.log(5) { x =>
+      3 + x
+    }
+
+    assert(res == 8)
+  }
 }

--- a/src/main/scala/gestalt/api.scala
+++ b/src/main/scala/gestalt/api.scala
@@ -73,6 +73,8 @@ object api extends Toolbox {
     Ident.apply("<empty>")
   }
 
+  def Ident(tp: TermRef)(implicit c: Dummy): tpd.Tree = Ident(Denotation.symbol(Type.denot(tp).get))
+
   /**------------------------------------------------*/
   // definitions
   def NewAnonymClass = toolbox.NewAnonymClass.asInstanceOf[NewAnonymClassImpl]

--- a/src/main/scala/gestalt/core/Trees.scala
+++ b/src/main/scala/gestalt/core/Trees.scala
@@ -322,6 +322,7 @@ trait Trees extends Params with TypeParams with
   def Lit: LitImpl
   trait LitImpl {
     def apply(value: Any): Lit
+    def typed(value: Any): tpd.Tree
     def unapply(tree: Tree): Option[Any]
     def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[Any]
   }
@@ -347,7 +348,6 @@ trait Trees extends Params with TypeParams with
   trait IdentImpl {
     def apply(name: String)(implicit unsafe: Unsafe): Ident
     def apply(symbol: Symbol): tpd.Tree
-    def apply(tp: TermRef)(implicit c: Dummy): tpd.Tree = Ident(Denotation.symbol(Type.denot(tp).get))
     def unapply(tree: Tree): Option[String]
     def unapply(tree: tpd.Tree)(implicit c: Dummy): Option[String]
   }


### PR DESCRIPTION
Previous implementation auto-updates owners when the typed constructors are used. However, it doesn't auto-update owners relative to the enclosing tree when `transform` is used. This PR reproduces the problem and proposes a fix.